### PR TITLE
docs: expand MetaVesT details

### DIFF
--- a/docs/pages/borgs/metavest.mdx
+++ b/docs/pages/borgs/metavest.mdx
@@ -11,12 +11,33 @@ MetaVesT is a BORG‑compatible vesting and token lockup protocol for ERC20 toke
 ## Key Capabilities
 
 - **Dual curves** – tokens can "vest" and "unlock" on independent schedules with optional cliffs.
-- **Options and restricted awards** – configure exercise or repurchase prices in stablecoins for tax‑optimized token grants.
+- **Options and restricted awards** – record token‑option exercise prices and restricted‑token repurchase prices in stablecoins to support 83(b) elections and capital‑gains treatment.
 - **Group amendments** – a majority‑in‑value of grantees plus the grantor can update terms for an entire cohort.
 - **Can't‑be‑evil guarantees** – unless an amendment is approved, vested tokens cannot be clawed back and only vesting can be terminated.
 - **Pass‑through voting** – unvested or locked tokens may still be staked and voted in a DAO.
 - **Milestones** – vesting can depend on discrete events as well as elapsed time.
 
+## How It Works
+
+MetaVesT escrows the grantor's tokens and issues non-transferable receipts to grantees. Each receipt tracks both vesting and unlocking curves along with optional price terms for options or repurchases. As time or milestones progress, the contract continually recalculates how many tokens are vested and unlocked. Grantees may withdraw the amount that satisfies both curves, while any excess remains locked in the vault.
+
+### Grant Lifecycle
+
+1. **Create grant** – the grantor deposits tokens and defines curves, cliffs and price terms.
+2. **Track progress** – time or milestone updates move tokens from unvested to vested and from locked to unlocked.
+3. **Withdraw tokens** – grantees can claim the lesser of the vested and unlocked amounts; unvested tokens stay escrowed.
+4. **Amend or terminate** – cohort‑wide amendments require majority approval plus the grantor. Otherwise, only vesting may be terminated.
+
+
+### Tax Optimization Mechanics
+
+- **Token‑option exercise price** – grantees can pay a preset stablecoin amount to turn options into tokens early, locking in the grant's fair market value and starting the capital‑gains holding period.
+- **Restricted‑token repurchase price** – the grantor may buy back unvested tokens at an agreed stablecoin price, enabling 83(b) elections without surprise ordinary‑income consequences if employment ends.
+
+These mechanics let MetaVesT mirror traditional equity plans and bake tax strategy directly into on‑chain grants.
+
 ## Uses
 
 MetaVesT can manage compensation for BORG personnel or govern how GrantsBORGs release tokens to recipients. It can also be paired with LeXscroW for escrowed token deals or with implants that respond to DAO approvals.
+
+The MetaVesT repository contains the Solidity contracts, deployment scripts and Foundry tests demonstrating linear schedules, cliffs, milestones and group amendments. Developers can explore the repository for examples of integrating the protocol with DAO governance or with modules like LeXscroW.


### PR DESCRIPTION
## Summary
- clarify MetaVesT internals and grant lifecycle
- link repository resources for developers
- highlight token-option exercise and restricted-token repurchase price mechanics for tax optimization

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e9faa91508332b778c73e0c462357