### PR TITLE
refactor: use onchain/offchain terminology

### DIFF
--- a/docs/pages/borgs/borg-core.mdx
+++ b/docs/pages/borgs/borg-core.mdx
@@ -6,7 +6,7 @@ content:
 
 # BORG Core
 
-[`borg-core`](https://github.com/MetaLex-Tech/borg-core) is the on-chain policy engine that powers MetaLeX BORGs. It combines a SAFE Guard with the standard ERC‑4824 DAO interface, making it the "heart" of every BORG on MetaLeX OS. The core manages high‑level policy, determining which actions multisig members may execute and how outside authorities interact with the BORG.
+[`borg-core`](https://github.com/MetaLex-Tech/borg-core) is the onchain policy engine that powers MetaLeX BORGs. It combines a SAFE Guard with the standard ERC‑4824 DAO interface, making it the "heart" of every BORG on MetaLeX OS. The core manages high‑level policy, determining which actions multisig members may execute and how outside authorities interact with the BORG.
 
 ## Architecture
 

--- a/docs/pages/borgs/borg-modes.mdx
+++ b/docs/pages/borgs/borg-modes.mdx
@@ -8,7 +8,7 @@ import { CardGrid, Card, Callout } from "@components";
 
 # BORGCORE Modes
 
-The borgCore is the central hub for on-chain BORGs. Its main purpose is to define the policy that governs which actions BORG members may take on chain. It extends the Gnosis Safe guard functionality.
+The borgCore is the central hub for onchain BORGs. Its main purpose is to define the policy that governs which actions BORG members may take on chain. It extends the Gnosis Safe guard functionality.
 
 <CardGrid>
 

--- a/docs/pages/borgs/conditions.mdx
+++ b/docs/pages/borgs/conditions.mdx
@@ -8,7 +8,7 @@ import { CardGrid, Card, Callout } from "@components";
 
 # Conditions
 
-Conditions define checks that must pass before the BORG core will forward a transaction. They can inspect state, timestamps, or any other on-chain data to ensure proposals comply with organizational rules.
+Conditions define checks that must pass before the BORG core will forward a transaction. They can inspect state, timestamps, or any other onchain data to ensure proposals comply with organizational rules.
 
 Conditions often work in tandem with [implants](/borgs/implants) to provide fine-grained control over what actions are allowed.
 

--- a/docs/pages/os/borg/borg-types/grantsborg.mdx
+++ b/docs/pages/os/borg/borg-types/grantsborg.mdx
@@ -14,12 +14,12 @@ import { CardGrid, Card, Callout } from "@components";
   BORG](https://forum.neutron.org/t/approved-proposal-14-launching-the-neutron-grants-program/95).
 </Callout>
 
-These BORGS follow a transparent and accountable process for evaluating grant proposals, making funding decisions, and monitoring the progress of funded projects. By doing so, Grant BORGs help ensure the long-term success and sustainability of the DAO and its ecosystem. Grant BORGs likely require a greater amount of social versatility and cannot be constrained as much through on-chain logic.
+These BORGS follow a transparent and accountable process for evaluating grant proposals, making funding decisions, and monitoring the progress of funded projects. By doing so, Grant BORGs help ensure the long-term success and sustainability of the DAO and its ecosystem. Grant BORGs likely require a greater amount of social versatility and cannot be constrained as much through onchain logic.
 
 <Callout>
   For example, there could be a rule that any single grant in excess of $250k of
   value requires the vote of both the management of the Grant BORG and a
-  majority of the DAO-and this could be enforced through on-chain logic (e.g. if
+  majority of the DAO-and this could be enforced through onchain logic (e.g. if
   BORG holds funds in multisig, expenditures over $250k require multisig
   supermajority with DAO being one of the votes).
 </Callout>

--- a/docs/pages/os/key-terms.mdx
+++ b/docs/pages/os/key-terms.mdx
@@ -23,7 +23,7 @@ MetaLeX OS can plug-and-play with any of these conceptions, but the MetaLeX team
 
 Put more simply, we view DAOs as limited-programmability robots where the limited programmability power is widely dispersed among users who can only adjust the program in accordance with hard-coded meta-programming rules.
 
-The riskiest liability vectors that could be associated with DAOs (clearly commercial and/or regulated off-chain activities such as investing in new projects, hiring workers for salaried off-chain jobs, etc.) should be treated as adjacent to the DAO rather than part of it, and should be housed in transparent, accountable, cybernetically enhanced DAO-adjacent entities: BORGs.
+The riskiest liability vectors that could be associated with DAOs (clearly commercial and/or regulated offchain activities such as investing in new projects, hiring workers for salaried offchain jobs, etc.) should be treated as adjacent to the DAO rather than part of it, and should be housed in transparent, accountable, cybernetically enhanced DAO-adjacent entities: BORGs.
 
 ## Directors ### 
 

--- a/docs/pages/os/metalex-os-intro.mdx
+++ b/docs/pages/os/metalex-os-intro.mdx
@@ -14,7 +14,7 @@ MetaLeX OS is the 'operating system' for cyBernetic ORGanizations, also as known
 
 MetaLeX OS consists of a system of BORG-optimized smart contracts, legal documents, offchain legal entity structures, and a web application for monitoring, operating and transacting with BORGs.
 
-Version 1 of BORG OS combines SAFE-compatible smart contracts and legal tooling to manufacture custom BORGs that separate powers between off-chain entities and on-chain automation. Built on the battle-tested Gnosis SAFE framework, it uses Guards to enforce pre- and post-transaction checks and Modules to automate actions like allowances, timelocks or ragequits. Together these components aim to create governance-accountable, trust-minimized and legally optimized multisig systems.
+Version 1 of BORG OS combines SAFE-compatible smart contracts and legal tooling to manufacture custom BORGs that separate powers between offchain entities and onchain automation. Built on the battle-tested Gnosis SAFE framework, it uses Guards to enforce pre- and post-transaction checks and Modules to automate actions like allowances, timelocks or ragequits. Together these components aim to create governance-accountable, trust-minimized and legally optimized multisig systems.
 
 **Jump right in**
 


### PR DESCRIPTION
## Summary
- standardize documentation terminology, replacing hyphenated “on-chain”/“off-chain” with “onchain”/“offchain”

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ea82fa0a88332a3cbc449b6b78d37