### PR TITLE
docs: expand borg implant and mode docs

### DIFF
--- a/docs/pages/borgs/borg-modes/blacklist.mdx
+++ b/docs/pages/borgs/borg-modes/blacklist.mdx
@@ -1,3 +1,13 @@
-# Example
+---
+showOutline: false
+content:
+  width: 75%
+---
 
-This is an example page.
+# Blacklist Mode
+
+The BORG core permits all actions except those explicitly denied.
+
+- Transfers to addresses on the blacklist are rejected.
+- Calls to disallowed contracts or methods fail unless parameters pass defined checks.
+- Useful for trusted operators who need flexibility while blocking known risks.

--- a/docs/pages/borgs/borg-modes/unrestricted.mdx
+++ b/docs/pages/borgs/borg-modes/unrestricted.mdx
@@ -1,0 +1,14 @@
+---
+showOutline: false
+content:
+  width: 75%
+---
+
+# Unrestricted Mode
+
+The BORG core does not enforce allow or deny lists.
+
+- Signers have full discretion over transactions.
+- Implants and condition checks can still be added for additional safeguards.
+- Suitable for experimentation or situations where members are highly trusted.
+

--- a/docs/pages/borgs/borg-modes/whitelist.mdx
+++ b/docs/pages/borgs/borg-modes/whitelist.mdx
@@ -1,0 +1,14 @@
+---
+showOutline: false
+content:
+  width: 75%
+---
+
+# Whitelist Mode
+
+Only pre‑approved addresses or calldata may execute transactions through the BORG core.
+
+- Native token transfers must target whitelisted recipients and may include per‑tx limits.
+- Contract calls are restricted to allowed methods with optional parameter constraints.
+- Best for high‑value treasuries or tightly controlled grants programs.
+

--- a/docs/pages/borgs/implants/dao-veto-grant.mdx
+++ b/docs/pages/borgs/implants/dao-veto-grant.mdx
@@ -8,3 +8,9 @@ content:
 
 Grants are queued for execution but may be cancelled by a DAO veto within a set period.
 
+- After a grant transaction is proposed, it enters a timelock managed by the implant.
+- Token holders or guardians can submit a veto during the delay.
+- If the veto window closes without action, the queued grant executes automatically from the BORG core.
+
+This pattern balances fast grant approval with a last‑resort safety valve controlled by the broader DAO.
+

--- a/docs/pages/borgs/implants/dao-vote-grant.mdx
+++ b/docs/pages/borgs/implants/dao-vote-grant.mdx
@@ -8,3 +8,7 @@ content:
 
 This implant requires a proposal to pass a DAO token holder vote before funds are released through the BORG core.
 
+- A grant proposal is created in the governance system and linked to the implant.
+- After the voting period, if the proposal meets quorum and approval thresholds, the BORG core is authorized to disburse funds.
+- Proposals that fail or expire never reach execution, keeping the treasury under community control.
+

--- a/docs/pages/borgs/implants/eject.mdx
+++ b/docs/pages/borgs/implants/eject.mdx
@@ -8,3 +8,11 @@ content:
 
 Provides a mechanism to remove a member or module from the BORG when predefined conditions are met.
 
+It can:
+
+- Allow a signer to voluntarily resign, triggering key rotation.
+- Enable the DAO to force-remove compromised or inactive participants.
+- Revoke modules that no longer meet governance standards.
+
+The eject implant helps keep the BORG membership and connected contracts healthy over time.
+

--- a/docs/pages/borgs/implants/fail-safe.mdx
+++ b/docs/pages/borgs/implants/fail-safe.mdx
@@ -8,3 +8,11 @@ content:
 
 A security implant that allows emergency pause or recovery actions if the BORG core becomes compromised.
 
+Typical configurations include:
+
+- Monitoring signer thresholds and redirecting funds to a designated recovery address if too many keys are lost.
+- Pausing outbound transactions while the DAO investigates suspicious activity.
+- Providing an escape hatch that can be triggered by a guardian account.
+
+Use the fail‑safe as a last line of defense for safeguarding treasury assets.
+

--- a/docs/pages/borgs/implants/optimistic-grant.mdx
+++ b/docs/pages/borgs/implants/optimistic-grant.mdx
@@ -8,3 +8,9 @@ content:
 
 Grants are automatically approved after a waiting period unless vetoed by the DAO.
 
+- Small grant requests can be executed quickly while still allowing token holders time to react.
+- Any participant may submit a veto transaction during the cooldown to block the payout.
+- If the window passes without objection, the grant executes from the BORG core.
+
+Optimistic grants speed up routine disbursements without sacrificing accountability.
+


### PR DESCRIPTION
## Summary
- flesh out DAO veto grant, DAO vote grant, eject, fail-safe, and optimistic grant implant docs
- document blacklist, whitelist, and unrestricted BORG core modes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eae5045a4833287faeae832a49437