### PR TITLE
Add make targets to silence npm proxy warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+NPM_ENV := npm_config_http_proxy= npm_config_https_proxy=
+
+install:
+	$(NPM_ENV) npm install
+
+build:
+	$(NPM_ENV) npm run build
+
+dev:
+	$(NPM_ENV) npm run dev
+
+preview:
+	$(NPM_ENV) npm run preview

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
+# MetaLeX OS Docs
+
 This is a [Vocs](https://vocs.dev) project bootstrapped with the Vocs CLI.
+
+## Development
+
+Use the provided `Makefile` targets to work with the project without seeing
+npm proxy warnings:
+
+```sh
+make install   # install dependencies
+make dev       # start local dev server
+make build     # create production build
+make preview   # preview the production build
+```
+
+The make targets clear proxy related environment variables before invoking
+npm, eliminating warnings such as `Unknown env config "http-proxy"`.


### PR DESCRIPTION
## Summary
- add Makefile targets that clear npm proxy env vars
- document Makefile usage to avoid npm `http-proxy` warnings

## Testing
- `CI=1 make build`


------
https://chatgpt.com/codex/tasks/task_e_688eb330b3008332b0b5af7ec4da598a