### PR TITLE
docs: rename bzBORG to bizBORG and reference cyberCORPs

### DIFF
--- a/docs/pages/borgs/intro-to-borgs.mdx
+++ b/docs/pages/borgs/intro-to-borgs.mdx
@@ -13,7 +13,7 @@ import { Callout } from "@components";
 For a more detailed description, see this Delphi Labs' seminal [article](https://delphilabs.medium.com/assimilating-the-borg-a-new-cryptolegal-framework-for-dao-adjacent-entities-569e54a43f83) on BORGs from 2023.
 </Callout>
 
- BORGs may be independent entities that use autonomous technologies in their operations—what we at MetaLeX call ‘bizBORGs’—or they may be “DAO-adjacent entities” that are funded by and undertake activities beneficial to larger DAOs, under a carefully constructed set of checks and balances.
+ BORGs may be independent entities that use autonomous technologies in their operations—what we at MetaLeX call ‘bizBORGs’ (also known as cyberCORPs)—or they may be “DAO-adjacent entities” that are funded by and undertake activities beneficial to larger DAOs, under a carefully constructed set of checks and balances.
 
 # BORG Design Principles
 

--- a/docs/pages/os/borg/borg-types.mdx
+++ b/docs/pages/os/borg/borg-types.mdx
@@ -39,9 +39,9 @@ BORGs lend themselves to an almost infinite number of uses and configurations. H
       genBORGs are general purpose BORGs that can be used for a wide variety of purposes.
     </span>
   </Card>
-    <Card title=">./bzBORG" link="/os/borg/borg-types/bzborg">
+    <Card title=">./bizBORG" link="/os/borg/borg-types/bizborg">
     <span>
-      bzBORGs are onchain corporations, including securitized entities.
+      bizBORGs (also known as cyberCORPs) are onchain corporations, including securitized entities.
     </span>
   </Card>
 </CardGrid>
@@ -79,22 +79,22 @@ With MetaLeX's modular design, grantBORGs can use any onchain Implant to add fun
       Unlock powerful vesting onchain contracts. Dual vesting 
     </span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create preapproved grants with rate limits and other controls.
     </span>
   </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with required DAO voting co-approval.
     </span>
   </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with time delay vetoable by the DAO.
     </span>
   </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bzborg">
+    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
     <span>
       Learn More.
     </span>

--- a/docs/pages/os/borg/borg-types/bizborg.mdx
+++ b/docs/pages/os/borg/borg-types/bizborg.mdx
@@ -1,0 +1,23 @@
+---
+showOutline: false
+content:
+    width: 75%
+---
+
+# bizBORG
+
+bizBORGs, also known as cyberCORPs, are onchain corporations that merge traditional legal structures with programmable smart contracts. By wrapping a multisig in a legal entity and enforcing policy onchain, they create governance‑accountable, trust‑minimized organizations that can operate and fund themselves directly on the blockchain.
+
+## Overview
+
+- Provide a cryptolegal framework for DAO‑adjacent or stand‑alone entities, separating real‑world corporate controls from digital execution.
+- Built on MetaLeX's BORGs OS to automate compliance and corporate actions through audited modules and guards.
+- Integrate with MetaLeX's cyberSAFE so companies can fundraise with regulation‑compliant SAFEs in just a few clicks.
+- Serve as a "cybernetic entity hub," enabling programmable fundraising and tokenized securities that are auditable and enforceable onchain.
+
+## Resources
+
+- [Assimilating the BORG: A New Cryptolegal Framework for DAO‑adjacent Entities](https://delphilabs.medium.com/assimilating-the-borg-a-new-cryptolegal-framework-for-dao-adjacent-entities-569e54a43f83)
+- [MetaLeX's cyberSAFE: Fund Your Company in a Few Clicks, Onchain](https://metalex.substack.com/p/metalexs-cybersafe-fund-your-company)
+- [cyberCORPs portal](https://cybercorps.metalex.tech/)
+- [cyberCORPs contracts](https://github.com/MetaLex-Tech/cybercorps-contracts)

--- a/docs/pages/os/borg/borg-types/devborg.mdx
+++ b/docs/pages/os/borg/borg-types/devborg.mdx
@@ -42,22 +42,22 @@ With MetaLeX's modular design, grantBORGs can use any onchain Implant to add fun
       Unlock powerful vesting onchain contracts. Dual vesting 
     </span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create preapproved grants with rate limits and other controls.
     </span>
   </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with required DAO voting co-approval.
     </span>
   </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with time delay vetoable by the DAO.
     </span>
   </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bzborg">
+    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
     <span>
       Learn More.
     </span>

--- a/docs/pages/os/borg/borg-types/finborg.mdx
+++ b/docs/pages/os/borg/borg-types/finborg.mdx
@@ -42,22 +42,22 @@ With MetaLeX's modular design, grantBORGs can use any onchain Implant to add fun
       Unlock powerful vesting onchain contracts. Dual vesting 
     </span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create preapproved grants with rate limits and other controls.
     </span>
   </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with required DAO voting co-approval.
     </span>
   </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with time delay vetoable by the DAO.
     </span>
   </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bzborg">
+    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
     <span>
       Learn More.
     </span>

--- a/docs/pages/os/borg/borg-types/genborg.mdx
+++ b/docs/pages/os/borg/borg-types/genborg.mdx
@@ -42,22 +42,22 @@ With MetaLeX's modular design, grantBORGs can use any onchain Implant to add fun
       Unlock powerful vesting onchain contracts. Dual vesting 
     </span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create preapproved grants with rate limits and other controls.
     </span>
   </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with required DAO voting co-approval.
     </span>
   </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with time delay vetoable by the DAO.
     </span>
   </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bzborg">
+    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
     <span>
       Learn More.
     </span>

--- a/docs/pages/os/borg/borg-types/grantsborg.mdx
+++ b/docs/pages/os/borg/borg-types/grantsborg.mdx
@@ -59,22 +59,22 @@ With MetaLeX's modular design, grantBORGs can use any onchain Implant to add fun
       Unlock powerful vesting onchain contracts. Dual vesting 
     </span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create preapproved grants with rate limits and other controls.
     </span>
   </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with required DAO voting co-approval.
     </span>
   </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with time delay vetoable by the DAO.
     </span>
   </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bzborg">
+    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
     <span>
       Learn More.
     </span>

--- a/docs/pages/os/borg/borg-types/securityborg.mdx
+++ b/docs/pages/os/borg/borg-types/securityborg.mdx
@@ -46,22 +46,22 @@ With MetaLeX's modular design, grantBORGs can use any onchain Implant to add fun
       Unlock powerful vesting onchain contracts. Dual vesting 
     </span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create preapproved grants with rate limits and other controls.
     </span>
   </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with required DAO voting co-approval.
     </span>
   </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bzborg">
+    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
     <span>
       Create grants with time delay vetoable by the DAO.
     </span>
   </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bzborg">
+    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
     <span>
       Learn More.
     </span>

--- a/docs/pages/os/dao/intro-to-borgs.mdx
+++ b/docs/pages/os/dao/intro-to-borgs.mdx
@@ -13,7 +13,7 @@ import { Callout } from "@components";
 For a more detailed description, see this Delphi Labs' seminal [article](https://delphilabs.medium.com/assimilating-the-borg-a-new-cryptolegal-framework-for-dao-adjacent-entities-569e54a43f83) on BORGs from 2023.
 </Callout>
 
- BORGs may be independent entities that use autonomous technologies in their operations—what we at MetaLeX call ‘bizBORGs’—or they may be “DAO-adjacent entities” that are funded by and undertake activities beneficial to larger DAOs, under a carefully constructed set of checks and balances.
+ BORGs may be independent entities that use autonomous technologies in their operations—what we at MetaLeX call ‘bizBORGs’ (also known as cyberCORPs)—or they may be “DAO-adjacent entities” that are funded by and undertake activities beneficial to larger DAOs, under a carefully constructed set of checks and balances.
 
 # BORG Design Principles
 

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -51,8 +51,8 @@ export default defineConfig({
               link: '/os/borg/borg-types/genborg',
             },
             {
-              text: 'bzBORG',
-              link: '/os/borg/borg-types/bzborg',
+              text: 'bizBORG (cyberCORP)',
+              link: '/os/borg/borg-types/bizborg',
             }
           ]
         },


### PR DESCRIPTION
## Summary
- rename bzBORG references and file paths to bizBORG and note they are also called cyberCORPs
- add dedicated bizBORG page explaining the cyberCORP concept with resource links
- update BORG introductions and navigation to include the cyberCORP terminology

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eb4d32a188332b3baadb0e2e84753