### PR TITLE
docs: unify BORG mode descriptions

### DIFF
--- a/docs/pages/borgs/borg-modes/blacklist.mdx
+++ b/docs/pages/borgs/borg-modes/blacklist.mdx
@@ -5,9 +5,7 @@ content:
 ---
 
 # Blacklist Mode
-
-The BORG core permits all actions except those explicitly denied.
-
-- Transfers to addresses on the blacklist are rejected.
-- Calls to disallowed contracts or methods fail unless parameters pass defined checks.
-- Useful for trusted operators who need flexibility while blocking known risks.
+- Transactions are permitted by default except those explicitly denied.
+- Addresses on the blacklist cannot receive transfers.
+- Contract calls or specific methods may be blocked unless parameters satisfy defined constraints.
+- Useful for trusted teams needing broad discretion while avoiding a short list of risky actions.

--- a/docs/pages/borgs/borg-modes/index.mdx
+++ b/docs/pages/borgs/borg-modes/index.mdx
@@ -18,7 +18,7 @@ The borgCore is the central hub for onchain BORGs. Its main purpose is to define
       link="/os/borg/borg-implants/borg-implant"
     >
       <span>
-        Only approved addresses or calldata may execute transactions.
+        Only pre-approved addresses or calldata may execute transactions.
       </span>
     </Card>
       <Card
@@ -26,7 +26,7 @@ The borgCore is the central hub for onchain BORGs. Its main purpose is to define
       link="/os/borg/borg-implants/borg-implant"
     >
       <span>
-        Transactions from listed addresses or calldata are blocked.
+        Transactions from blacklisted addresses or calldata are blocked.
       </span>
     </Card>
     <Card title="Unrestricted" link="/os/borg/borg-implants/borg-implant">
@@ -39,7 +39,7 @@ The borgCore is the central hub for onchain BORGs. Its main purpose is to define
 ### Whitelist
 
 - All transactions are blocked unless explicitly pre‑approved.
-- Only designated recipients can receive native token transfers, each with optional per‑tx limits.
+- Native token transfers must target whitelisted recipients and may include per‑tx limits.
 - Calls are limited to whitelisted contracts and methods, with parameter constraints such as type, ranges or exact values.
 - Best for highly conservative BORGs holding significant value, like finBORGs or tightly controlled grants programs.
 
@@ -53,6 +53,7 @@ The borgCore is the central hub for onchain BORGs. Its main purpose is to define
 ### Unrestricted
 
 - No allow or deny lists are enforced.
-- Intended for BORGs where signers have full discretion but still want access to implants or MetaLeX tooling.
+- Signers have full discretion over transactions but can still use implants or other MetaLeX tooling for optional safeguards.
+- Suitable for experimentation or situations where members are highly trusted.
 
 Both whitelist and blacklist modes can enforce cooldown periods on certain calls to prevent spammy proposals or denial‑of‑service patterns.

--- a/docs/pages/borgs/borg-modes/unrestricted.mdx
+++ b/docs/pages/borgs/borg-modes/unrestricted.mdx
@@ -5,10 +5,7 @@ content:
 ---
 
 # Unrestricted Mode
-
-The BORG core does not enforce allow or deny lists.
-
-- Signers have full discretion over transactions.
-- Implants and condition checks can still be added for additional safeguards.
+- No allow or deny lists are enforced.
+- Signers have full discretion over transactions but can still use implants or other MetaLeX tooling for optional safeguards.
 - Suitable for experimentation or situations where members are highly trusted.
 

--- a/docs/pages/borgs/borg-modes/whitelist.mdx
+++ b/docs/pages/borgs/borg-modes/whitelist.mdx
@@ -5,10 +5,8 @@ content:
 ---
 
 # Whitelist Mode
-
-Only pre‑approved addresses or calldata may execute transactions through the BORG core.
-
+- All transactions are blocked unless explicitly pre‑approved.
 - Native token transfers must target whitelisted recipients and may include per‑tx limits.
-- Contract calls are restricted to allowed methods with optional parameter constraints.
-- Best for high‑value treasuries or tightly controlled grants programs.
+- Calls are limited to whitelisted contracts and methods, with parameter constraints such as type, ranges or exact values.
+- Best for highly conservative BORGs holding significant value, like finBORGs or tightly controlled grants programs.
 


### PR DESCRIPTION
## Summary
- standardize BORG mode descriptions across overview and individual pages
- clarify whitelist, blacklist, and unrestricted behaviors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eb8f29f9483329930998b290dde22