### PR TITLE
chore: clear npm proxy env in setup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-NPM_ENV := npm_config_http_proxy= npm_config_https_proxy=
+NPM := ./scripts/npm.sh
 
 install:
-	$(NPM_ENV) npm install
+	$(NPM) install
 
 build:
-	$(NPM_ENV) npm run build
+	$(NPM) run build
 
 dev:
-	$(NPM_ENV) npm run dev
+	$(NPM) run dev
 
 preview:
-	$(NPM_ENV) npm run preview
+	$(NPM) run preview

--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ make build     # create production build
 make preview   # preview the production build
 ```
 
-The make targets clear proxy related environment variables before invoking
-npm, eliminating warnings such as `Unknown env config "http-proxy"`.
+The make targets call `scripts/npm.sh`, which clears proxy-related
+environment variables before invoking `npm`. This eliminates warnings such as
+`Unknown env config "http-proxy"`. You can also run the wrapper directly, for
+example `./scripts/npm.sh test`.

--- a/scripts/npm.sh
+++ b/scripts/npm.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clear proxy-related npm config to avoid deprecation warnings
+unset npm_config_http_proxy
+unset npm_config_https_proxy
+
+npm "$@"


### PR DESCRIPTION
## Summary
- silence npm proxy warnings by wrapping npm with proxy-clearing script
- run npm tasks through wrapper via Makefile
- document npm wrapper usage in README

## Testing
- `make install`
- `make build`
- `./scripts/npm.sh test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688eb966fff083328ea0e3418373d750