### PR TITLE
docs: expand borg introduction

### DIFF
--- a/docs/pages/borgs/intro-to-borgs.mdx
+++ b/docs/pages/borgs/intro-to-borgs.mdx
@@ -7,13 +7,26 @@ import { Callout } from "@components";
 
 # What is a BORG? 
 
-‘BORGs’ is short for ‘cyBernetic ORGanizationS’: BORGs are cybernetic entities. BORGs are traditional entities (corporations, limited liability companies, foundations, etc.) that legally mandate the use of autonomous technologies (such as smart contracts and AI) to conduct some or all of their operations and/or governance. Augmenting the entities with autonomous technologies enhances efficiency, trust minimization and ‘social scalability’ while reducing liability and regulatory risks.
+‘BORGs’ is short for ‘cyBernetic ORGanizationS’: BORGs are cybernetic entities. They are traditional entities (corporations, limited liability companies, foundations, etc.) whose charters legally embed autonomous software—such as smart contracts and AI—to conduct some or all of their operations and governance. Augmenting entities with autonomous technologies enhances efficiency, trust minimization and ‘social scalability’ while reducing liability and regulatory risks.
 
 <Callout>
 For a more detailed description, see this Delphi Labs' seminal [article](https://delphilabs.medium.com/assimilating-the-borg-a-new-cryptolegal-framework-for-dao-adjacent-entities-569e54a43f83) on BORGs from 2023.
 </Callout>
 
- BORGs may be independent entities that use autonomous technologies in their operations—what we at MetaLeX call ‘bizBORGs’ (also known as cyberCORPs)—or they may be “DAO-adjacent entities” that are funded by and undertake activities beneficial to larger DAOs, under a carefully constructed set of checks and balances.
+BORGs generally fall into two broad categories:
+
+- **Tech-augmented companies** – independent entities that embed autonomous software into their operations; at MetaLeX we call these “bizBORGs” or cyberCORPs.
+- **Trust-mitigated, DAO-adjacent entities** – organizations funded by and undertaking activities beneficial to larger DAOs under carefully constructed checks and balances.
+
+DAO-adjacent BORGs can take many forms—common examples include **security BORGs** for emergency controls, **grants BORGs** to distribute treasury funds, or **IP BORGs** to steward trademarks and software rights.
+
+Some charters even require all digital assets to sit in a public multisig at a specified address. The DAO can veto changes to that multisig or revoke its powers entirely, ensuring on-chain transparency with legal accountability.
+
+From the outside BORGs may operate like DAOs, but their legal entity charters enforce automated decisions for accountability.
+
+Rather than wrapping DAOs in new liabilities, the BORG framework preserves the original vision of DAOs. By re‑characterizing certain “DAOs” as business BORGs and shifting legally sensitive activities to DAO‑adjacent BORGs, true DAOs can stay lean, autonomous, and cypherpunk.
+
+MetaLeX’s mission is to fuse law and code. Our [BORG OS](/os/metalex-os-intro) provides a customizable suite of SAFE-compatible smart contracts and legal tooling that make it easy to deploy trust-minimized, legally optimized multisig governance for these entities.
 
 # BORG Design Principles
 
@@ -23,9 +36,9 @@ BORGs are part of a new design space where hybrid/code law solutions should be g
 
 Maximize the role of trust-minimized smart contracts and other autonomous or decentralized technologies to handle as many deterministic functions as possible. This includes using autonomous technologies such as smart contracts as  replacements for traditional legal arrangements that prescribe relatively deterministic rules.
 
-Minimize the role of traditional law (TradLaw) tools such as ‘wet contracts’ and litigation as much as possible in the operations and governance of legal entities and other legal arrangements. When ‘wet contracts’ are required, they be designed to refer and to defer to the outcomes of autonomous code as much as possible
+Minimize the role of traditional law (TradLaw) tools such as ‘wet contracts’ and litigation as much as possible in the operations and governance of legal entities and other legal arrangements. When ‘wet contracts’ are required, they should be designed to refer and to defer to the outcomes of autonomous code as much as possible
 
-**Principle 2 –Qualify Autonomous Code Where Necessary**
+**Principle 2 – Qualify Autonomous Code Where Necessary**
 
 Identify edge-cases in which Principle #1 may lead to unacceptably unfair, unjust, or unanticipated results and use TradLaw mechanisms to ensure that autonomous code is not outcome-determinative code in these particular circumstances. Instead, offchain legal mechanisms can kick-in to handle these special scenarios in a more fair, just, and legal way.
 


### PR DESCRIPTION
## Summary
- clarify how BORG charters embed autonomous software for governance
- enumerate tech-augmented and DAO-adjacent BORG types and link to BORG OS
- highlight common DAO-adjacent roles, multisig charter requirements, and how BORGs preserve DAO autonomy

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ec02c674c8332ab2133470287f4c2