### PR TITLE
docs: refine OS documentation

### DIFF
--- a/docs/pages/os/borg/borg-landing.mdx
+++ b/docs/pages/os/borg/borg-landing.mdx
@@ -3,7 +3,7 @@ showOutline: false
 content: 
     width: 75%
 ---
-import { CardGrid, Card, Callout } from "@components";
+import { CardGrid, Card } from "@components";
 
 # BORG Command Center
 
@@ -14,7 +14,7 @@ import { CardGrid, Card, Callout } from "@components";
 **Learn more about how to use BORGs using MetaLeX OS**
   <Card
     title="BORG Members"
-    link="/os/borg/borg-implants/borg-implant"
+    link="/os/borg/how-to"
   >
     <span>
       Learn how to take actions in MetaLeX OS as a BORG member.
@@ -22,15 +22,16 @@ import { CardGrid, Card, Callout } from "@components";
   </Card>
     <Card
     title="DAO Member"
-    link="/os/borg/borg-implants/borg-implant"
+    link="/os/dao/dao-landing"
   >
     <span>
       Learn how to take actions in MetaLeX OS as a DAO Token Holder.
     </span>
   </Card>
-  <Card title="Types of BORGs" link="/os/borg/borg-implants/borg-implant">
+  <Card title="Types of BORGs" link="/os/borg/borg-types">
     <span>
       Learn more about the different specializations of BORGs.
     </span>
   </Card>
 </CardGrid>
+

--- a/docs/pages/os/borg/borg-types.mdx
+++ b/docs/pages/os/borg/borg-types.mdx
@@ -1,174 +1,60 @@
 ---
 showOutline: false
-content: 
+content:
     width: 75%
 ---
-
-import { CardGrid, Card, Callout } from "@components";
+import { CardGrid, Card } from "@components";
 
 # BORG Types
 
-BORGs lend themselves to an almost infinite number of uses and configurations. Here we give a few examples.
+BORGs lend themselves to an almost infinite number of uses and configurations. Here are a few examples.
 
 <CardGrid>
-  <Card
-    title=">./grantsBORG"
-    link="/os/borg/borg-types/grantsborg"
-  >
-    <span>
-      grantsBORGS are BORGs that manage grants and donations for a DAO or protocol.
-    </span>
+  <Card title="grantsBORG" link="/os/borg/borg-types/grantsborg">
+    <span>Manage grants and donations for a DAO or protocol.</span>
   </Card>
-    <Card title=">./securityBORG" link="/os/borg/borg-types/secborg">
-    <span>
-      securityBORGs wrap emergency/security multisigs to respond to critical events. 
-    </span>
+  <Card title="securityBORG" link="/os/borg/borg-types/securityborg">
+    <span>Wrap emergency multisigs to handle critical events.</span>
   </Card>
-  <Card title=">./ipBORG" link="/os/borg/borg-types/ipborg">
-    <span>
-      ipBORGs manage and protect the intellectual property assets associated with a DAO.
-    </span>
+  <Card title="ipBORG" link="/os/borg/borg-types/ipborg">
+    <span>Oversee intellectual property for a DAO.</span>
   </Card>
-  <Card title=">./finBORG" link="/os/borg/borg-types/finborg">
-    <span>
-      finBORGs handle protocol beneficial value (PBV) and token management operations.
-    </span>
+  <Card title="finBORG" link="/os/borg/borg-types/finborg">
+    <span>Handle protocol-beneficial value and treasury operations.</span>
   </Card>
-  <Card title=">./genBORG" link="/os/borg/borg-types/genborg">
-    <span>
-      genBORGs are general purpose BORGs that can be used for a wide variety of purposes.
-    </span>
+  <Card title="allianceBORG" link="/os/borg/borg-types/allianceborg">
+    <span>Coordinate aligned token holdings and partnerships.</span>
   </Card>
-    <Card title=">./bizBORG" link="/os/borg/borg-types/bizborg">
-    <span>
-      bizBORGs (also known as cyberCORPs) are onchain corporations, including securitized entities.
-    </span>
+  <Card title="genBORG" link="/os/borg/borg-types/genborg">
+    <span>General-purpose BORG for human-in-the-loop functions.</span>
+  </Card>
+  <Card title="bizBORG" link="/os/borg/borg-types/bizborg">
+    <span>Onchain corporations, also known as cyberCORPs.</span>
   </Card>
 </CardGrid>
 
-With MetaLeX's modular design, grantBORGs can use any onchain Implant to add functionality to enhance or customize the BORG to your needs.
+## BORG Implants
 
-**BORG Implants**
+MetaLeX's modular design lets any BORG use onchain implants to enhance or customize its capabilities.
 
 <CardGrid>
-  <Card
-    title="FailSafe_Implant"
-    link="/borgs/implants/fail-safe"
-  >
-    <span>
-      Protect the funds in your BORG. Handles recovery and DAO oversight.
-    </span>
+  <Card title="FailSafe_Implant" link="/borgs/implants/fail-safe">
+    <span>Protect funds with recovery and DAO oversight.</span>
   </Card>
-  <Card title="Eject_Implant" link="/os/borg/borg-types/devborg">
-    <span>
-      Manage BORG Members. Also allows self-ejecting from a Safe/BORG.
-    </span>
+  <Card title="Eject_Implant" link="/borgs/implants/eject">
+    <span>Manage members or allow self-ejection from a SAFE.</span>
   </Card>
-  <Card title="DAOVote_Implant" link="/os/borg/borg-types/secborg">
-    <span>
-     Enable DAO voting with any governance mechanism w/ custom controls.
-    </span>
+  <Card title="OptimisticGrant_Implant" link="/borgs/implants/optimistic-grant">
+    <span>Create preapproved grants with rate limits.</span>
   </Card>
-  <Card title="DAOVeto_Implant" link="/os/borg/borg-types/genborg">
-    <span>
-      Enable time-based proposals vetoable by the DAO w/ custom controls
-    </span>
+  <Card title="DAOVoteGrant_Implant" link="/borgs/implants/dao-vote-grant">
+    <span>Require DAO voting co-approval for grants.</span>
   </Card>
-  <Card title="MetaVesT_Implant" link="/os/borg/borg-types/finborg">
-    <span>
-      Unlock powerful vesting onchain contracts. Dual vesting 
-    </span>
+  <Card title="DAOVetoGrant_Implant" link="/borgs/implants/dao-veto-grant">
+    <span>Add time-delay grants that the DAO can veto.</span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create preapproved grants with rate limits and other controls.
-    </span>
-  </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with required DAO voting co-approval.
-    </span>
-  </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with time delay vetoable by the DAO.
-    </span>
-  </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
-    <span>
-      Learn More.
-    </span>
+  <Card title="MetaVesT" link="/borgs/metavest">
+    <span>Advanced vesting and token lockup toolkit.</span>
   </Card>
 </CardGrid>
 
-
-### Borg Implants
-
-<CardGrid>
-  <Card
-    title="Borg Implant"
-    link="/os/borg/borg-implants/borg-implant"
-  >
-    <span>
-      Borg Implants are SAFE Modules included in MetaLeX OS and designed to make
-      SAFEs function as parts of BORGs.
-    </span>
-  </Card>
-  <Card title="Borg Implant" link="/os/borg/borg-implants/borg-implant">
-    <span>
-      Borg Implants are SAFE Modules included in MetaLeX OS and designed to make
-      SAFEs function as parts of BORGs.
-    </span>
-  </Card>
-  <Card title="Borg Implant" link="/os/borg/borg-implants/borg-implant">
-    <span>
-      Borg Implants are SAFE Modules included in MetaLeX OS and designed to make
-      SAFEs function as parts of BORGs.
-    </span>
-  </Card>
-  <Card title="Borg Implant" link="/os/borg/borg-implants/borg-implant">
-    <span>
-      Borg Implants are SAFE Modules included in MetaLeX OS and designed to make
-      SAFEs function as parts of BORGs.
-    </span>
-  </Card>
-  <Card title="Borg Implant" link="/os/borg/borg-implants/borg-implant">
-    <span>
-      Borg Implants are SAFE Modules included in MetaLeX OS and designed to make
-      SAFEs function as parts of BORGs.
-    </span>
-  </Card>
-</CardGrid>
-
-
-fin-BORGs or pbv-BORGs
-finBORGs run the 'finance operations' adjacent to a DAO or protocol. These include managing liquidity incentives like Lido's [LOL multisig](https://research.lido.fi/t/liquidity-observation-lab-lol-liquidity-strategy-and-application-to-curve-steth-eth-pool/5335/7), or arrangeements closer to OlympusDAO/DeFi 2.0 style 'protocol-owned liquidity' arrangements (which we at MetaleX instead refer to as 'protocol-beneficial value' when it is owned/managed by a BORG).
-
-alliiance-BORGs
-Alliance BORGs hold and manage token positions of aligned communities/strategic partners and manage those relationships.
-
-An example is the [Lido Alliance BORG](https://research.lido.fi/t/organize-the-lido-alliance-program-as-a-lido-dao-adjacent-borg/8173)
-
-IP-BORGs
-Intellectual Property (IP) BORGs manage and protect the intellectual property assets associated with a DAO, such as patents, trademarks, copyrights, and trade secrets. These BORGs work to ensure that the DAO’s IP is properly registered, maintained, and enforced, while also respecting the rights of others in the ecosystem. IP BORGs also play a crucial role in negotiating licensing agreements, partnerships, and other arrangements that involve the sharing or transfer of intellectual property rights. This helps to foster innovation, collaboration, and the responsible use of IP within the decentralized ecosystem.
-
-
-<Callout>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec nunc
-  euismod, elit nisi luctus nunc, euismod euismod nisi luctus nunc.
-</Callout>
-
-<Callout type="warning">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec nunc
-  euismod, elit nisi luctus nunc, euismod euismod nisi luctus nunc.
-</Callout>
-
-<Callout type="security">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec nunc
-  euismod, elit nisi luctus nunc, euismod euismod nisi luctus nunc.
-</Callout>
-
-<Callout type="check">
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec nunc
-  euismod, elit nisi luctus nunc, euismod euismod nisi luctus nunc.
-</Callout>

--- a/docs/pages/os/borg/borg-types/allianceborg.mdx
+++ b/docs/pages/os/borg/borg-types/allianceborg.mdx
@@ -1,15 +1,19 @@
 ---
 showOutline: false
-content: 
+content:
     width: 75%
 ---
-import { CardGrid, Card } from "@components";
+import { CardGrid, Card, Callout } from "@components";
 
-## finBORGs / pbvBORGS
+## allianceBORGs
 
-finBORGs handle the efforts of protocol beneficial value (PBV) and token management operations. They can be used to manage the vesting of tokens, the distribution of tokens, and the management of token-based incentives. finBORGs can also be used to manage the treasury of a DAO or protocol, and to manage the financial operations of a DAO or protocol.
+Alliance BORGs hold and manage token positions of aligned communities and strategic partners. They consolidate cross-DAO stakes and steward relationships to advance mutual goals.
 
-With MetaLeX's modular design, finBORGs can use onchain implants to enhance or customize the BORG to your needs.
+<Callout>
+  An example is the [Lido Alliance BORG](https://research.lido.fi/t/organize-the-lido-alliance-program-as-a-lido-dao-adjacent-borg/8173).
+</Callout>
+
+With MetaLeX's modular design, allianceBORGs can use onchain implants to enhance or customize the BORG to their needs.
 
 **BORG Implants**
 
@@ -33,3 +37,4 @@ With MetaLeX's modular design, finBORGs can use onchain implants to enhance or c
     <span>Advanced vesting and token lockup toolkit.</span>
   </Card>
 </CardGrid>
+

--- a/docs/pages/os/borg/borg-types/bizborg.mdx
+++ b/docs/pages/os/borg/borg-types/bizborg.mdx
@@ -21,3 +21,4 @@ bizBORGs, also known as cyberCORPs, are onchain corporations that merge traditio
 - [MetaLeX's cyberSAFE: Fund Your Company in a Few Clicks, Onchain](https://metalex.substack.com/p/metalexs-cybersafe-fund-your-company)
 - [cyberCORPs portal](https://cybercorps.metalex.tech/)
 - [cyberCORPs contracts](https://github.com/MetaLex-Tech/cybercorps-contracts)
+

--- a/docs/pages/os/borg/borg-types/devborg.mdx
+++ b/docs/pages/os/borg/borg-types/devborg.mdx
@@ -3,63 +3,33 @@ showOutline: false
 content: 
     width: 75%
 ---
-import { CardGrid, Card, Callout } from "@components";
+import { CardGrid, Card } from "@components";
 
 ## devBORGs
 
 devBORGs are BORGs that manage the development and deployment of smart contracts and other technical assets for a DAO or protocol. They are responsible for the technical operations of a DAO, including the deployment of new smart contracts, the management of technical assets, and the coordination of technical resources.
 
-With MetaLeX's modular design, grantBORGs can use any onchain Implant to add functionality to enhance or customize the BORG to your needs.
+With MetaLeX's modular design, devBORGs can use onchain implants to enhance or customize the BORG to your needs.
 
 **BORG Implants**
 
 <CardGrid>
-  <Card
-    title="FailSafe_Implant"
-    link="/borgs/implants/fail-safe"
-  >
-    <span>
-      Protect the funds in your BORG. Handles recovery and DAO oversight.
-    </span>
+  <Card title="FailSafe_Implant" link="/borgs/implants/fail-safe">
+    <span>Protect funds with recovery and DAO oversight.</span>
   </Card>
-  <Card title="Eject_Implant" link="/os/borg/borg-types/devborg">
-    <span>
-      Manage BORG Members. Also allows self-ejecting from a Safe/BORG.
-    </span>
+  <Card title="Eject_Implant" link="/borgs/implants/eject">
+    <span>Manage members or allow self-ejection from a SAFE/BORG.</span>
   </Card>
-  <Card title="DAOVote_Implant" link="/os/borg/borg-types/secborg">
-    <span>
-     Enable DAO voting with any governance mechanism w/ custom controls.
-    </span>
+  <Card title="OptimisticGrant_Implant" link="/borgs/implants/optimistic-grant">
+    <span>Create preapproved grants with rate limits.</span>
   </Card>
-  <Card title="DAOVeto_Implant" link="/os/borg/borg-types/genborg">
-    <span>
-      Enable time-based proposals vetoable by the DAO w/ custom controls
-    </span>
+  <Card title="DAOVoteGrant_Implant" link="/borgs/implants/dao-vote-grant">
+    <span>Require DAO voting co-approval for grants.</span>
   </Card>
-  <Card title="MetaVesT_Implant" link="/os/borg/borg-types/finborg">
-    <span>
-      Unlock powerful vesting onchain contracts. Dual vesting 
-    </span>
+  <Card title="DAOVetoGrant_Implant" link="/borgs/implants/dao-veto-grant">
+    <span>Add time-delay grants that the DAO can veto.</span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create preapproved grants with rate limits and other controls.
-    </span>
-  </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with required DAO voting co-approval.
-    </span>
-  </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with time delay vetoable by the DAO.
-    </span>
-  </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
-    <span>
-      Learn More.
-    </span>
+  <Card title="MetaVesT" link="/borgs/metavest">
+    <span>Advanced vesting and token lockup toolkit.</span>
   </Card>
 </CardGrid>

--- a/docs/pages/os/borg/borg-types/genborg.mdx
+++ b/docs/pages/os/borg/borg-types/genborg.mdx
@@ -3,63 +3,33 @@ showOutline: false
 content: 
     width: 75%
 ---
-import { CardGrid, Card, Callout } from "@components";
+import { CardGrid, Card } from "@components";
 
 ## genBORGs
 
 genBORGs are generalBORGs, short for general purpose BORGs, that can be used for a wide variety of purposes. Handling Human-in-the-loop functionality for protocols, they can assist anywhere a DAO needs interaction with the physical or legal world.
 
-With MetaLeX's modular design, grantBORGs can use any onchain Implant to add functionality to enhance or customize the BORG to your needs.
+With MetaLeX's modular design, genBORGs can use onchain implants to enhance or customize the BORG to your needs.
 
 **BORG Implants**
 
 <CardGrid>
-  <Card
-    title="FailSafe_Implant"
-    link="/borgs/implants/fail-safe"
-  >
-    <span>
-      Protect the funds in your BORG. Handles recovery and DAO oversight.
-    </span>
+  <Card title="FailSafe_Implant" link="/borgs/implants/fail-safe">
+    <span>Protect funds with recovery and DAO oversight.</span>
   </Card>
-  <Card title="Eject_Implant" link="/os/borg/borg-types/devborg">
-    <span>
-      Manage BORG Members. Also allows self-ejecting from a Safe/BORG.
-    </span>
+  <Card title="Eject_Implant" link="/borgs/implants/eject">
+    <span>Manage members or allow self-ejection from a SAFE/BORG.</span>
   </Card>
-  <Card title="DAOVote_Implant" link="/os/borg/borg-types/secborg">
-    <span>
-     Enable DAO voting with any governance mechanism w/ custom controls.
-    </span>
+  <Card title="OptimisticGrant_Implant" link="/borgs/implants/optimistic-grant">
+    <span>Create preapproved grants with rate limits.</span>
   </Card>
-  <Card title="DAOVeto_Implant" link="/os/borg/borg-types/genborg">
-    <span>
-      Enable time-based proposals vetoable by the DAO w/ custom controls
-    </span>
+  <Card title="DAOVoteGrant_Implant" link="/borgs/implants/dao-vote-grant">
+    <span>Require DAO voting co-approval for grants.</span>
   </Card>
-  <Card title="MetaVesT_Implant" link="/os/borg/borg-types/finborg">
-    <span>
-      Unlock powerful vesting onchain contracts. Dual vesting 
-    </span>
+  <Card title="DAOVetoGrant_Implant" link="/borgs/implants/dao-veto-grant">
+    <span>Add time-delay grants that the DAO can veto.</span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create preapproved grants with rate limits and other controls.
-    </span>
-  </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with required DAO voting co-approval.
-    </span>
-  </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with time delay vetoable by the DAO.
-    </span>
-  </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
-    <span>
-      Learn More.
-    </span>
+  <Card title="MetaVesT" link="/borgs/metavest">
+    <span>Advanced vesting and token lockup toolkit.</span>
   </Card>
 </CardGrid>

--- a/docs/pages/os/borg/borg-types/grantsborg.mdx
+++ b/docs/pages/os/borg/borg-types/grantsborg.mdx
@@ -26,57 +26,27 @@ These BORGS follow a transparent and accountable process for evaluating grant pr
 
 Grant BORGs present particularly sensitive tax issues because they are, in effect, paying service providers (with potential to be responsible for tax withholding, tax reporting, social security contributions, VAT, etc.), and thus there might be a need for multiple Grant BORGs in different jurisdictions where grant recipients reside.
 
-With MetaLeX's modular design, grantBORGs can use any onchain Implant to add functionality to enhance or customize the BORG to your needs.
+With MetaLeX's modular design, grantBORGs can use onchain implants to enhance or customize the BORG to their needs.
 
 **BORG Implants**
 
 <CardGrid>
-  <Card
-    title="FailSafe_Implant"
-    link="/borgs/implants/fail-safe"
-  >
-    <span>
-      Protect the funds in your BORG. Handles recovery and DAO oversight.
-    </span>
+  <Card title="FailSafe_Implant" link="/borgs/implants/fail-safe">
+    <span>Protect funds with recovery and DAO oversight.</span>
   </Card>
-  <Card title="Eject_Implant" link="/os/borg/borg-types/devborg">
-    <span>
-      Manage BORG Members. Also allows self-ejecting from a Safe/BORG.
-    </span>
+  <Card title="Eject_Implant" link="/borgs/implants/eject">
+    <span>Manage members or allow self-ejection from a SAFE/BORG.</span>
   </Card>
-  <Card title="DAOVote_Implant" link="/os/borg/borg-types/secborg">
-    <span>
-     Enable DAO voting with any governance mechanism w/ custom controls.
-    </span>
+  <Card title="OptimisticGrant_Implant" link="/borgs/implants/optimistic-grant">
+    <span>Create preapproved grants with rate limits.</span>
   </Card>
-  <Card title="DAOVeto_Implant" link="/os/borg/borg-types/genborg">
-    <span>
-      Enable time-based proposals vetoable by the DAO w/ custom controls
-    </span>
+  <Card title="DAOVoteGrant_Implant" link="/borgs/implants/dao-vote-grant">
+    <span>Require DAO voting co-approval for grants.</span>
   </Card>
-  <Card title="MetaVesT_Implant" link="/os/borg/borg-types/finborg">
-    <span>
-      Unlock powerful vesting onchain contracts. Dual vesting 
-    </span>
+  <Card title="DAOVetoGrant_Implant" link="/borgs/implants/dao-veto-grant">
+    <span>Add time-delay grants that the DAO can veto.</span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create preapproved grants with rate limits and other controls.
-    </span>
-  </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with required DAO voting co-approval.
-    </span>
-  </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with time delay vetoable by the DAO.
-    </span>
-  </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
-    <span>
-      Learn More.
-    </span>
+  <Card title="MetaVesT" link="/borgs/metavest">
+    <span>Advanced vesting and token lockup toolkit.</span>
   </Card>
 </CardGrid>

--- a/docs/pages/os/borg/borg-types/ipborg.mdx
+++ b/docs/pages/os/borg/borg-types/ipborg.mdx
@@ -1,15 +1,13 @@
 ---
 showOutline: false
-content: 
+content:
     width: 75%
 ---
 import { CardGrid, Card } from "@components";
 
-## finBORGs / pbvBORGS
+## ipBORGs
 
-finBORGs handle the efforts of protocol beneficial value (PBV) and token management operations. They can be used to manage the vesting of tokens, the distribution of tokens, and the management of token-based incentives. finBORGs can also be used to manage the treasury of a DAO or protocol, and to manage the financial operations of a DAO or protocol.
-
-With MetaLeX's modular design, finBORGs can use onchain implants to enhance or customize the BORG to your needs.
+ipBORGs manage and protect the intellectual property assets associated with a DAO, such as patents, trademarks, copyrights and trade secrets. They help ensure that a DAO's IP is properly registered, maintained and enforced while facilitating licensing agreements and partnerships.
 
 **BORG Implants**
 
@@ -33,3 +31,4 @@ With MetaLeX's modular design, finBORGs can use onchain implants to enhance or c
     <span>Advanced vesting and token lockup toolkit.</span>
   </Card>
 </CardGrid>
+

--- a/docs/pages/os/borg/borg-types/securityborg.mdx
+++ b/docs/pages/os/borg/borg-types/securityborg.mdx
@@ -13,57 +13,27 @@ Security BORGs wrap emergency/security multisigs to respond to critical events. 
 One example is Curve's ['emergency DAO'](https://resources.curve.fi/governance/understanding-governance/#emergency-dao) (which we at MetaLeX would preferably refer to as an 'emergency BORG' instead).
 </Callout>
 
-With MetaLeX's modular design, grantBORGs can use any onchain Implant to add functionality to enhance or customize the BORG to your needs.
+With MetaLeX's modular design, securityBORGs can use onchain implants to enhance or customize the BORG to their needs.
 
 **BORG Implants**
 
 <CardGrid>
-  <Card
-    title="FailSafe_Implant"
-    link="/borgs/implants/fail-safe"
-  >
-    <span>
-      Protect the funds in your BORG. Handles recovery and DAO oversight.
-    </span>
+  <Card title="FailSafe_Implant" link="/borgs/implants/fail-safe">
+    <span>Protect funds with recovery and DAO oversight.</span>
   </Card>
-  <Card title="Eject_Implant" link="/os/borg/borg-types/devborg">
-    <span>
-      Manage BORG Members. Also allows self-ejecting from a Safe/BORG.
-    </span>
+  <Card title="Eject_Implant" link="/borgs/implants/eject">
+    <span>Manage members or allow self-ejection from a SAFE/BORG.</span>
   </Card>
-  <Card title="DAOVote_Implant" link="/os/borg/borg-types/secborg">
-    <span>
-     Enable DAO voting with any governance mechanism w/ custom controls.
-    </span>
+  <Card title="OptimisticGrant_Implant" link="/borgs/implants/optimistic-grant">
+    <span>Create preapproved grants with rate limits.</span>
   </Card>
-  <Card title="DAOVeto_Implant" link="/os/borg/borg-types/genborg">
-    <span>
-      Enable time-based proposals vetoable by the DAO w/ custom controls
-    </span>
+  <Card title="DAOVoteGrant_Implant" link="/borgs/implants/dao-vote-grant">
+    <span>Require DAO voting co-approval for grants.</span>
   </Card>
-  <Card title="MetaVesT_Implant" link="/os/borg/borg-types/finborg">
-    <span>
-      Unlock powerful vesting onchain contracts. Dual vesting 
-    </span>
+  <Card title="DAOVetoGrant_Implant" link="/borgs/implants/dao-veto-grant">
+    <span>Add time-delay grants that the DAO can veto.</span>
   </Card>
-    <Card title="OtimisticGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create preapproved grants with rate limits and other controls.
-    </span>
-  </Card>
-    <Card title="DAOVoteGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with required DAO voting co-approval.
-    </span>
-  </Card>
-    <Card title="DAOVetoGrant_Implant" link="/os/borg/borg-types/bizborg">
-    <span>
-      Create grants with time delay vetoable by the DAO.
-    </span>
-  </Card>
-    <Card title="+ Custom Implants to fit your specialized needs" link="/os/borg/borg-types/bizborg">
-    <span>
-      Learn More.
-    </span>
+  <Card title="MetaVesT" link="/borgs/metavest">
+    <span>Advanced vesting and token lockup toolkit.</span>
   </Card>
 </CardGrid>

--- a/docs/pages/os/borg/how-to.mdx
+++ b/docs/pages/os/borg/how-to.mdx
@@ -3,41 +3,26 @@ showOutline: false
 content: 
     width: 75%
 ---
-import { CardGrid, Card, Callout } from "@components";
+import { Callout } from "@components";
 
 # "How-to" BORG
 
 # ![Logo](/borg-connect.png)
 
-Get Started with BORGs in MetaLeX OS. To unlock actions based on your connected wallet's privileges, Click the "Connect Wallet" button in the top right corner of MetaLeX OS and follow the steps.
+Get started with BORGs in MetaLeX OS. To unlock actions based on your connected wallet's privileges, click the "Connect Wallet" button in the top right corner of MetaLeX OS and follow the steps.
 
 <Callout>
-  Actions available in MetaLeX OS will change depending on what privileges your connected wallet has. It can support actions from BORG members as well as DAO token holders.
+  Actions available in MetaLeX OS change depending on the privileges of your connected wallet. The interface supports actions for both BORG members and DAO token holders.
 </Callout>
 
-**Learn more about how to use BORGs using MetaLeX OS**
+## Basic workflow
 
-<CardGrid>
-  <Card
-    title="BORG Members"
-    link="/os/borg/borg-implants/borg-implant"
-  >
-    <span>
-      Learn how to take actions in MetaLeX OS as a BORG member.
-    </span>
-  </Card>
-    <Card
-    title="DAO Member"
-    link="/os/borg/borg-implants/borg-implant"
-  >
-    <span>
-      Learn how to take actions in MetaLeX OS as a DAO Token Holder.
-    </span>
-  </Card>
-  <Card title="Types of BORGs" link="/os/borg/borg-implants/borg-implant">
-    <span>
-      Learn more about the different specializations of BORGs.
-    </span>
-  </Card>
-</CardGrid>
+1. **Connect your wallet** using the button in the upper-right corner of the app.
+2. **Select the BORG** you want to interact with from the dashboard.
+3. **Review your permissions** to see whether you can propose or approve transactions.
+4. **Submit or confirm actions** directly in the interface. MetaLeX OS guides you through the required signatures or DAO votes.
+5. **Track execution** in the activity feed to verify when transactions are finalized onchain.
+
+For an overview of available BORG types, visit the [BORG Command Center](/os/borg/borg-landing).
+
 

--- a/docs/pages/os/dao/dao-landing.mdx
+++ b/docs/pages/os/dao/dao-landing.mdx
@@ -1,0 +1,31 @@
+---
+showOutline: false
+content:
+    width: 75%
+---
+import { CardGrid, Card, Callout } from "@components";
+
+# DAO Member Guide
+
+MetaLeX OS lets DAO token holders monitor and influence the BORGs that serve their communities.
+
+<Callout>
+  The actions you can take depend on the governance rights attached to your tokens.
+</Callout>
+
+## Basic workflow
+
+1. **Connect your wallet** using the button in the upper-right corner.
+2. **Review available proposals** for BORG actions or onchain votes.
+3. **Cast your vote** or sign off on transactions when prompted by the interface.
+4. **Track results** to see when approved actions execute onchain.
+
+<CardGrid>
+  <Card title="BORG Command Center" link="/os/borg/borg-landing">
+    <span>Return to the BORG command center.</span>
+  </Card>
+  <Card title="Intro to BORGs" link="/os/dao/intro-to-borgs">
+    <span>Learn what BORGs are and why they matter.</span>
+  </Card>
+</CardGrid>
+

--- a/docs/pages/os/dao/intro-to-borgs.mdx
+++ b/docs/pages/os/dao/intro-to-borgs.mdx
@@ -32,3 +32,4 @@ Identify edge-cases in which Principle #1 may lead to unacceptably unfair, unjus
 **Principle 3 - Use TradLaw Mechanisms to Constrain Offchain Agents**
 
 If there are humans in the loop and such humans, despite the use of autonomous technologies, remain in positions of ‘trust’ and thus retain significant potential for acting based on conflicts of interest, abusing their discretion, adversely colluding, cultivating information asymmetries, free-riding, or otherwise abusing their power, we must use traditional ‘wet contracts’ and other legal tools to define their rights and obligations clearly and hold them accountable if such trust is indeed abused. Principle #3 may also be seen as a special sub-case of Principle #2, since in such cases autonomous code by itself is inadequate to achieve trust-minimization or social scaling—however, under Principle #3, law is used more as a supplement to code than as a fallback mechanism for code failures.
+

--- a/docs/pages/os/key-terms.mdx
+++ b/docs/pages/os/key-terms.mdx
@@ -19,7 +19,7 @@ There is no clear consensus about what a “DAO” is and how it should be defin
 MetaLeX OS can plug-and-play with any of these conceptions, but the MetaLeX team prefers sticking to the literal meaning of the acronym “D.A.O.” — i.e., that DAOs must be decentralized and autonomous organizations, where:
  * “Autonomous” means self-governing, trust-minimized and resistant to extrinsic exercises of power. 
  * “Decentralized” means that any residual human discretion (i.e., intrinsic modalities of power) are systematically dispersed over a large, agile, and potentially anonymous group of incentive-aligned persons.
- * "Organization" refers to whatever structures or people are organized through the relevant auotnomous decentralized technologies. 
+ * "Organization" refers to whatever structures or people are organized through the relevant autonomous decentralized technologies.
 
 Put more simply, we view DAOs as limited-programmability robots where the limited programmability power is widely dispersed among users who can only adjust the program in accordance with hard-coded meta-programming rules.
 
@@ -27,11 +27,11 @@ The riskiest liability vectors that could be associated with DAOs (clearly comme
 
 ## Directors ### 
 
-Directors are individuals or entities with supervisory and/or operational authority over a legal entity. The exact scope and mechanisms through which directors manage an entity vary dependingon the entity type, jurisdiction, and the entity's specific rules (especially Bylaws). In the context of BORGs, directors are likely to be owners of private-key-signers on one or more SAFEs/multisigs included in the BORG. MetaLeX OS recognizes a specific 'director role' within multisigs, which is basically a subset of signers a majority of whom *must* approve a given transaction for it to execute. 
+Directors are individuals or entities with supervisory and/or operational authority over a legal entity. The exact scope and mechanisms through which directors manage an entity vary depending on the entity type, jurisdiction, and the entity's specific rules (especially Bylaws). In the context of BORGs, directors are likely to be owners of private-key-signers on one or more SAFEs/multisigs included in the BORG. MetaLeX OS recognizes a specific 'director role' within multisigs, which is basically a subset of signers a majority of whom *must* approve a given transaction for it to execute.
 
 ## Guardians ### 
 
-Guardian is a role with no well-defined corporate precedent, but was created as a hybrid entity/SAFE role specifically for BORGs. Guardians are members of a SAFE/multisig within a BORG that are on the SAFE primarily to provide additional security (through wider distribution of private keys/signing power) or quality control and compliance checks, but do not have authorities/powers as broad as those of directors. Part of the reason for having the guardian role is that the KYC/AML and compliance obligations of a legtal entity's directors may be very high, meaning that it is hard to obtain a large number of directors to serve on a BORG, but, meanwhile, for reasons of increasing the security of tokens held by a SAFE, it is desirable to have a greater number of private key holders to lower the risk of 'wrench attacks' and other physical attacks as well as loss of keys or unavailability/downtime of signers in an emergency. A BORG's SAFE/multisig may therefore be required to require the approval of both a majority of the directors and some minimum number of guardians before a transatcion will execute from the SAFE/multisig. 
+Guardian is a role with no well-defined corporate precedent, but was created as a hybrid entity/SAFE role specifically for BORGs. Guardians are members of a SAFE/multisig within a BORG that are on the SAFE primarily to provide additional security (through wider distribution of private keys/signing power) or quality control and compliance checks, but do not have authorities/powers as broad as those of directors. Part of the reason for having the guardian role is that the KYC/AML and compliance obligations of a legal entity's directors may be very high, meaning that it is hard to obtain a large number of directors to serve on a BORG, but, meanwhile, for reasons of increasing the security of tokens held by a SAFE, it is desirable to have a greater number of private key holders to lower the risk of 'wrench attacks' and other physical attacks as well as loss of keys or unavailability/downtime of signers in an emergency. A BORG's SAFE/multisig may therefore be required to require the approval of both a majority of the directors and some minimum number of guardians before a transaction will execute from the SAFE/multisig.
 
 ## Legal Entity ### 
 
@@ -39,11 +39,11 @@ A legal entity is an organization that is given independent personhood through t
 
 ## Multisig aka SAFE ###
 
-See [SAFE aka Multisig below](). 
+See [SAFE aka Multisig below](#safe-aka-multisig).
 
 ## SAFE aka Multisig ###
 
-SAFEs, aka multisigs or 'smart accounts' are smart contracts implementing [the Gnosis SAFE source code](https://github.com/safe-global/safe-smart-account). These are smart contract multi-sig 'wallets' running on Ethereum that require a minimum number of private key signatures (corresponding to public addresses on Ehtereum) to approve a transaction before it can be executed by the smart contract. Typically in the BORG context, each public/private key address is owned/controlled by a different human individual. 
+SAFEs, aka multisigs or 'smart accounts' are smart contracts implementing [the Gnosis SAFE source code](https://github.com/safe-global/safe-smart-account). These are smart contract multi-sig 'wallets' running on Ethereum that require a minimum number of private key signatures (corresponding to public addresses on Ethereum) to approve a transaction before it can be executed by the smart contract. Typically in the BORG context, each public/private key address is owned/controlled by a different human individual.
 
 ## SAFE Guard ###
 
@@ -72,3 +72,4 @@ LeXscroW is a suite of ownerless, condition-driven escrow contracts. Escrows enf
 ## MetaVesT ###
 
 MetaVesT is an advanced vesting and token lockup protocol. It enables dual vesting and unlocking curves, option-style grants, group amendments and milestone-based releases while ensuring vested tokens cannot be rugged without consent.
+

--- a/docs/pages/os/metalex-os-intro.mdx
+++ b/docs/pages/os/metalex-os-intro.mdx
@@ -2,7 +2,7 @@
 content: 
   width: 75%
 ---
-import { CardGrid, Card, Callout } from "@components";
+import { CardGrid, Card } from "@components";
 import { LuShield } from "react-icons/lu";
 import { HiComputerDesktop } from "react-icons/hi2";
 import { LiaFileContractSolid } from "react-icons/lia";
@@ -30,13 +30,13 @@ Version 1 of BORG OS combines SAFE-compatible smart contracts and legal tooling 
   </Card>
   <Card
    title="Command Center"
-   link="/os/borg/borg-implants/borg-implant"
+   link="/os/borg/borg-landing"
    icon={<HiComputerDesktop />}>
     <span>
       MetaLeX OS operating guide.
     </span>
   </Card>
-  <Card title="On Chain Contracts" link="/os/borg/borg-implants/borg-implant" icon={<LiaFileContractSolid />}>
+  <Card title="On Chain Contracts" link="/borgs/implants" icon={<LiaFileContractSolid />}>
     <span>
       Details on the smart contracts that power BORGs.
     </span>


### PR DESCRIPTION
## Summary
- overhaul OS intro links and command center navigation
- add DAO member guide and step-by-step BORG workflow
- clean up BORG type pages and key-term definitions
- restore allianceBORG documentation and link it from the type index

## Testing
- `npm test` (fails: Missing script: "test")
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ec582c7a083329071672a6516f3cd