### PR TITLE
Reorder Cybernetic Law doc navigation

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -163,21 +163,21 @@ export default defineConfig({
           link: '/metavest',
         },
         {
+          text: '⚖️ Cybernetic Law',
+          collapsed: false,
+          items: [
+            {
+              text: 'Intro to Cybernetic Law',
+              link: '/cybernetic-law/intro-to-cybernetic-law',
+            },
+          ],
+        },
+        {
           text: 'LeXscroW',
           link: '/lexscrow',
         },
       ],
     },
-    {
-      text: '⚖️ Cybernetic Law',
-      collapsed: false,
-      items: [
-        {
-          text: 'Intro to Cybernetic Law',
-          link: '/cybernetic-law/intro-to-cybernetic-law',
-        },
-      ],
-    }
   ],
   vite: {
     resolve: {


### PR DESCRIPTION
## Summary
- Move Cybernetic Law docs into the main MetaLeX OS sidebar section
- Position Cybernetic Law directly beneath MetaVesT and above LeXscroW

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_688edffdeee88332baac7c3e8ce30496