### PR TITLE
docs: add cyberCORPs section

### DIFF
--- a/docs/pages/cybercorps.mdx
+++ b/docs/pages/cybercorps.mdx
@@ -1,0 +1,55 @@
+---
+showOutline: false
+content:
+  width: 75%
+---
+
+# 🏢 cyberCORPs
+
+cyberCORPs fuse traditional corporate structures with programmable smart contracts.
+This section outlines planned documentation for building and operating a cyberCORP
+on MetaLeX OS.
+
+## Overview
+
+- Explain how cyberCORPs differ from BORGs and where they intersect.
+- Discuss the rationale for tokenizing corporate equity and governance.
+- Highlight the [cyberCORP app](https://cybercorps.metalex.tech/) for raising capital.
+
+## On‑Chain Capital Structure
+
+- Describe the **IssuanceManager** and **CyberCertPrinter** contracts used to mint
+  digital stock certificates.
+- Map security classes and series to tokenized shares as discussed in
+  "Tokenizing Corporate Capital Stock".
+- Note how Substack research explains bridging legal stock ledgers with NFTs.
+
+## Deal Flow and Agreements
+
+- Introduce the **DealManager** and **CyberAgreementRegistry** for proposing,
+  signing and finalizing agreements.
+- Show how LexScroWLite escrows assets and enforces conditions.
+- Provide examples of YC‑style SAFEs and hybrid token deals mentioned in public
+  announcements.
+
+## Governance and Officers
+
+- Outline BorgAuth‑based role control and how company officers are added or removed.
+- Document fields such as entity name, jurisdiction, dispute resolution and
+  payable address.
+- Suggest a subsection on upgrades via the upgrade factory.
+
+## Launching a cyberCORP
+
+- Step through creating a corporation via `CyberCorpFactory` or the web app.
+- Recommend linking to the `cybercorps-contracts` repository for deployment
+  scripts and templates.
+- Include instructions for issuing certificates, managing deals and integrating
+  with MetaVesT or LeXscroW.
+
+## Future Integrations
+
+- Speculate on combining cyberCORPs with BORG implants for automated compliance.
+- Mention potential DAO bridges, on‑chain accounting or regulatory oracles.
+- Capture outstanding questions from the community for further research.
+

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -159,6 +159,10 @@ export default defineConfig({
           ],
         },
         {
+          text: '🏢 cyberCORPs',
+          link: '/cybercorps',
+        },
+        {
           text: '⏳ MetaVesT',
           link: '/metavest',
         },


### PR DESCRIPTION
## Summary
- insert sidebar link for new cyberCORPs docs section
- draft cyberCORPs page outlining planned subsections and content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ee4544cb8833282b8ecc36649cc1f