### PR TITLE
docs: add overview links to MetaLeX OS intro

### DIFF
--- a/docs/pages/os/metalex-os-intro.mdx
+++ b/docs/pages/os/metalex-os-intro.mdx
@@ -1,11 +1,7 @@
 ---
-content: 
+content:
   width: 75%
 ---
-import { CardGrid, Card } from "@components";
-import { LuShield } from "react-icons/lu";
-import { HiComputerDesktop } from "react-icons/hi2";
-import { LiaFileContractSolid } from "react-icons/lia";
 
 # ![Logo](/header.png)
 # 🖖 Welcome to MetaLeX OS
@@ -16,29 +12,19 @@ MetaLeX OS consists of a system of BORG-optimized smart contracts, legal documen
 
 Version 1 of BORG OS combines SAFE-compatible smart contracts and legal tooling to manufacture custom BORGs that separate powers between offchain entities and onchain automation. Built on the battle-tested Gnosis SAFE framework, it uses Guards to enforce pre- and post-transaction checks and Modules to automate actions like allowances, timelocks or ragequits. Together these components aim to create governance-accountable, trust-minimized and legally optimized multisig systems.
 
-**Jump right in**
+## Documentation Overview
 
-<CardGrid>
-  <Card
-    title="Intro To Borgs"
-    link="/os/dao/intro-to-borgs"
-    icon={<LuShield />}
-  >
-    <span>
-        Primer on BORGs
-    </span>
-  </Card>
-  <Card
-   title="Command Center"
-   link="/os/borg/borg-landing"
-   icon={<HiComputerDesktop />}>
-    <span>
-      MetaLeX OS operating guide.
-    </span>
-  </Card>
-  <Card title="On Chain Contracts" link="/os/borg/implants" icon={<LiaFileContractSolid />}>
-    <span>
-      Details on the smart contracts that power BORGs.
-    </span>
-  </Card>
-</CardGrid>
+- [Key Terms](/os/key-terms) — definitions of BORG and DAO vocabulary.
+- [BORG Command Center](/os/borg/borg-landing) — hub for operating a BORG.
+  - [How-to BORG](/os/borg/how-to) — step-by-step interface guide.
+  - [BORG Core](/os/borg/borg-core) — policy engine architecture.
+  - [Conditions](/os/borg/conditions) — rules that gate transactions.
+  - [BORG Modes](/os/borg/borg-modes): [Whitelist](/os/borg/borg-modes/whitelist), [Blacklist](/os/borg/borg-modes/blacklist), [Unrestricted](/os/borg/borg-modes/unrestricted).
+  - [BORG Types](/os/borg/borg-types): [grantsBORG](/os/borg/borg-types/grantsborg), [securityBORG](/os/borg/borg-types/securityborg), [ipBORG](/os/borg/borg-types/ipborg), [finBORG](/os/borg/borg-types/finborg), [allianceBORG](/os/borg/borg-types/allianceborg), [genBORG](/os/borg/borg-types/genborg), [bizBORG](/os/borg/borg-types/bizborg), [devBORG](/os/borg/borg-types/devborg).
+  - [Implants](/os/borg/implants): [Optimistic Grant](/os/borg/implants/optimistic-grant), [DAO Vote Grant](/os/borg/implants/dao-vote-grant), [DAO Veto Grant](/os/borg/implants/dao-veto-grant), [Eject](/os/borg/implants/eject), [Fail Safe](/os/borg/implants/fail-safe).
+- [DAO Member Guide](/os/dao/dao-landing) — how token holders participate.
+- [Intro to BORGs](/os/dao/intro-to-borgs) — background on BORG concepts.
+- [cyberCORPs](/cybercorps) — tokenized corporate structures.
+- [LeXscroW](/lexscrow) — ownerless condition-based escrow.
+- [MetaVesT](/metavest) — vesting and token lockup toolkit.
+- [Cybernetic Law](/cybernetic-law/intro-to-cybernetic-law) — legal framework for onchain entities.


### PR DESCRIPTION
## Summary
- expand MetaLeX OS intro with links to every major documentation section

## Testing
- `CI=1 ./scripts/npm.sh run build`


------
https://chatgpt.com/codex/tasks/task_e_688f580c2de483328f6f7504800bcd13