### PR TITLE
Add Legal Approach subsection to BORGs docs

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -26,6 +26,10 @@ export default defineConfig({
                 link: '/borg/intro-to-borgs',
             },
             {
+              text: 'Legal Approach',
+                link: '/borg/legal-approach',
+            },
+            {
               text: 'borgCORE',
                 link: '/borg/borg-core',
             },


### PR DESCRIPTION
## Summary
- Add Legal Approach page to BORGs sidebar above borgCORE

## Testing
- `npm test` (fails: Missing script "test")
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f86118e5c8332aea3b2e60ae3c16b