### PR TITLE
docs: hyperlink sources in legal approach page

### DIFF
--- a/docs/pages/borg/legal-approach.mdx
+++ b/docs/pages/borg/legal-approach.mdx
@@ -76,17 +76,17 @@ MetaLeX’s legal approach to BORGs demonstrates that we can achieve decentraliz
 
 ## Sources
 
-* Delphi Labs – **“Assimilating the BORG: A New Framework for CryptoLaw Entities”** (Apr 20, 2023)
+* Delphi Labs – **“[Assimilating the BORG: A New Framework for CryptoLaw Entities](https://delphilabs.medium.com/assimilating-the-borg-a-new-framework-for-cryptolaw-entities-7910ec216a7b)”** (Apr 20, 2023)
 
-* Yearn Improvement Proposal (YIP-XX) – **“Convert Ychad.ETH Into a BORG”** (Jul 2025)
+* Yearn Improvement Proposal (YIP-XX) – **“[Convert Ychad.ETH Into a BORG](https://gov.yearn.fi/t/yip-xx-convert-ychad-eth-into-a-borg/14531)”** (Jul 2025)
 
-* Lido Governance Proposal – **“Organize the Lido Alliance Program as a Lido-DAO-Adjacent BORG”** (Aug 2024)
+* Lido Governance Proposal – **“[Organize the Lido Alliance Program as a Lido-DAO-Adjacent BORG](https://research.lido.fi/t/organize-the-lido-alliance-program-as-a-lido-dao-adjacent-borg/8173)”** (Aug 2024)
 
-* MetaLeX (Gabriel Shapiro) – **Yearn BORG Proposal, Part 1-2 Discussions**
+* MetaLeX (Gabriel Shapiro) – **[Yearn BORG Proposal, Part 1](https://metalex.substack.com/p/yearn-borg-proposal-part-1)** & **[Part 2](https://metalex.substack.com/p/yearn-borg-proposal-part-2)** Discussions
 
-* Everclear DAO – **Everclear Foundation Documentation** (GitBook, 2023)
+* Everclear DAO – **[Everclear Foundation Documentation](https://dao-docs.everclear.org/collective/everclear-foundation)** (GitBook, 2023)
 
-* zkSync Governance Docs – **Security Council and Guardians** (2024)
+* zkSync Governance Docs – **[Security Council and Guardians](https://docs.zknation.io/zksync-governance-procedures/zksync-governance-procedures-overview)** (2024)
 
-* *Additional references:* Lido Alliance BORG legal docs (Bylaws, etc.); Everclear Governance Lab summary; Neutron Grants Program Proposal; MetaLeX Newsletter and Whitepaper excerpts.
+* *Additional references:* [Lido Alliance BORG legal docs](https://docs.lido.fi/multisigs/alliance/); [Everclear Governance Lab summary](https://github.com/connext/everclear-gitbook); [Neutron Grants Program Proposal](https://forum.neutron.org/t/approved-proposal-14-launching-the-neutron-grants-program/95); [MetaLeX Newsletter and Whitepaper excerpts](https://metalex.substack.com).
 


### PR DESCRIPTION
## Summary
- hyperlink all references in the Legal Approach to DAO-Adjacent BORGs docs page
- include links to Lido, Yearn, Everclear, zkSync, and MetaLeX resources

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f974534048332ac76df0b90dba5a8