### PR TITLE
docs: refresh MetaLeX OS table of contents

### DIFF
--- a/docs/pages/metalex-os-intro.mdx
+++ b/docs/pages/metalex-os-intro.mdx
@@ -14,14 +14,38 @@ MetaLeX OS is the cybernetic law 'operating system' that puts entities, their go
 - BORGs — BORGs and BORGs OS, relating to DAO-adjacent onchain entities.
   - [What is a BORG?](/borg/what-is-a-BORG) — background on BORG concepts.
   - [BORG Core](/borg/borg-core) — policy engine architecture.
-  - [BORG Modes](/borg/borg-modes): [Whitelist](/borg/borg-modes/whitelist), [Blacklist](/borg/borg-modes/blacklist), [Unrestricted](/borg/borg-modes/unrestricted).
-  - [Implants](/borg/implants): [Optimistic Grant](/borg/implants/optimistic-grant), [DAO Vote Grant](/borg/implants/dao-vote-grant), [DAO Veto Grant](/borg/implants/dao-veto-grant), [Eject](/borg/implants/eject), [Fail Safe](/borg/implants/fail-safe).
+  - BORG Modes
+    - [Whitelist](/borg/borg-modes/whitelist)
+    - [Blacklist](/borg/borg-modes/blacklist)
+    - [Unrestricted](/borg/borg-modes/unrestricted)
+  - Implants
+    - [Optimistic Grant](/borg/implants/optimistic-grant)
+    - [DAO Vote Grant](/borg/implants/dao-vote-grant)
+    - [DAO Veto Grant](/borg/implants/dao-veto-grant)
+    - [Eject](/borg/implants/eject)
+    - [Fail Safe](/borg/implants/fail-safe)
   - [Conditions](/borg/conditions) — rules that gate transactions.
-  - [BORG Types](/borg/borg-types): [grantsBORG](/borg/borg-types/grantsborg), [securityBORG](/borg/borg-types/securityborg), [ipBORG](/borg/borg-types/ipborg), [finBORG](/borg/borg-types/finborg), [allianceBORG](/borg/borg-types/allianceborg), [genBORG](/borg/borg-types/genborg), [bizBORG](/borg/borg-types/bizborg), [devBORG](/borg/borg-types/devborg).
+  - BORG Types
+    - [grantsBORG](/borg/borg-types/grantsborg)
+    - [securityBORG](/borg/borg-types/securityborg)
+    - [ipBORG](/borg/borg-types/ipborg)
+    - [finBORG](/borg/borg-types/finborg)
+    - [allianceBORG](/borg/borg-types/allianceborg)
+    - [genBORG](/borg/borg-types/genborg)
+    - [bizBORG](/borg/borg-types/bizborg)
+    - [devBORG](/borg/borg-types/devborg)
   - [BORG Command Center](/borg/borg-landing) — hub for operating a BORG.
     - [How-to BORG](/borg/how-to) — step-by-step interface guide.
     - [DAO Member Guide](/borg/dao-landing) — how token holders participate.
-- [cyberCORPs](/cybercorps) — real-world onchain business entities, their tokenized securities and their onchain dealmaking
+  - [Legal Approach](/borg/legal-approach) — bridging onchain actions with real-world law.
+- [cyberCORPs](/cybercorps) — real-world onchain business entities, their tokenized securities, and their onchain dealmaking.
+  - [What is a cyberCORP?](/cybercorps/what-is-a-cyberCORP)
+  - [Governance and Officers](/cybercorps/governance-and-officers)
+  - [Onchain Capital Structure](/cybercorps/onchain-capital-structure)
+  - [Launching a cyberCORP](/cybercorps/launching-a-cybercorp)
+  - [Deal Flow and Agreements](/cybercorps/deal-flow-and-agreements)
+  - [Future Integrations](/cybercorps/future-integrations)
+  - [Sources](/cybercorps/sources)
 - [LeXscroW](/lexscrow) — ownerless condition-based escrow for BORGs and cyberCORPs.
 - [MetaVesT](/metavest) — vesting and token lockup toolkit for BORGs and cyberCORPs.
-- [Cybernetic Law](/cybernetic-law/intro-to-cybernetic-law) — legal framework for onchain entities and cybernetic transactions
+- [Cybernetic Law](/cybernetic-law/intro-to-cybernetic-law) — legal framework for onchain entities and cybernetic transactions.


### PR DESCRIPTION
## Summary
- expand MetaLeX OS intro table of contents to enumerate all docs
- add nested listings for BORG modes, implants, types, command center, and legal approach
- include comprehensive cyberCORPs subpages

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fb03e04488332b4c6f6fe943f4921