### PR TITLE
docs: add LeXcheX subsection

### DIFF
--- a/docs/pages/cybercorps/index.mdx
+++ b/docs/pages/cybercorps/index.mdx
@@ -16,5 +16,6 @@ cyberCORPs fuse traditional corporate structures with programmable smart contrac
 - [Deal Flow and Agreements](/cybercorps/deal-flow-and-agreements)
 - [Governance and Officers](/cybercorps/governance-and-officers)
 - [Launching a cyberCORP](/cybercorps/launching-a-cybercorp)
+- [LeXcheX](/cybercorps/lexchex)
 - [Future Integrations](/cybercorps/future-integrations)
 - [Sources](/cybercorps/sources)

--- a/docs/pages/cybercorps/lexchex.mdx
+++ b/docs/pages/cybercorps/lexchex.mdx
@@ -1,0 +1,17 @@
+---
+showOutline: false
+content:
+  width: 75%
+---
+
+# LeXcheX
+
+LeXcheX brings automated investor accreditation and agreement execution to cyberCORPs. The service issues onchain credentials proving that a wallet belongs to an accredited investor, allowing compliant fundraising without manual review.
+
+## How it fits in cyberCORPs
+
+- **Automated accreditation**: Investors obtain a LeXcheX credential that proves their status without exposing personal data.
+- **Onchain compliance**: cyberCORPs can gate token sales or security transfers based on the credential.
+- **Streamlined fundraising**: Founders raise capital from qualified investors with fewer intermediaries and lower legal overhead.
+
+For more background, see the [LinkedIn announcement](https://www.linkedin.com/posts/gabriel-shapiro-984083249_metalex-is-now-offering-lexchexautomating-activity-7353823351372460032-ODFr).


### PR DESCRIPTION
## Summary
- document LeXcheX, MetaLeX's onchain investor accreditation tool for cyberCORPs
- link LeXcheX page from the cyberCORPs index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ffa61517c83329c4e2b94c0e6b112