### PR TITLE
docs: add LeXcheX to sidebar

### DIFF
--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -188,6 +188,10 @@ export default defineConfig({
               link: '/cybercorps/launching-a-cybercorp',
             },
             {
+              text: 'LeXcheX',
+              link: '/cybercorps/lexchex',
+            },
+            {
               text: 'Future Integrations',
               link: '/cybercorps/future-integrations',
             },


### PR DESCRIPTION
## Summary
- Show LeXcheX in the cyberCORPs sidebar so docs navigation includes this section.

## Testing
- `./scripts/npm.sh test`
- `CI=1 ./scripts/npm.sh run build` *(hangs after `building bundles...`)*

------
https://chatgpt.com/codex/tasks/task_e_688ffcd58bd88332b196b7949ba93b63