### PR TITLE
docs: add cyberRaise section under cyberDeals

### DIFF
--- a/docs/pages/cyberdeals/cyberraise.mdx
+++ b/docs/pages/cyberdeals/cyberraise.mdx
@@ -1,0 +1,14 @@
+---
+showOutline: false
+content:
+  width: 75%
+---
+
+# 🚀 cyberRaise
+
+**cyberRaise** is MetaLeX Labs’ compliant early‑stage fundraising app. Built on top of the cyberCORPS OS and the cyberDeals stack, it lets founders propose, negotiate and close venture deals entirely onchain.
+
+The application lives at [cybercorps.metalex.tech](https://cybercorps.metalex.tech/) and integrates modules like [LeXcheX](/cyberdeals/lexchex) for accredited‑investor verification and [LeXscroW](/cyberdeals/lexscrow) for non‑custodial escrow. SAFEs, token warrants and hybrid agreements are executed through smart contracts, ensuring that capital moves only when all terms are satisfied.
+
+An early version of this concept was outlined in [MetaLeX’s “cybersafe” fundraising article](https://metalex.substack.com/p/metalexs-cybersafe-fund-your-company), and cyberRaise continues that vision toward a full‑featured, rule‑compliant VC platform.
+

--- a/docs/pages/cyberdeals/index.mdx
+++ b/docs/pages/cyberdeals/index.mdx
@@ -14,3 +14,4 @@ cyberDeals brings MetaLeX's onchain deal tooling under one umbrella.
 - [LeXcheX](/cyberdeals/lexchex)
 - [MetaVesT](/cyberdeals/metavest)
 - [LeXscroW](/cyberdeals/lexscrow)
+- [cyberRaise](/cyberdeals/cyberraise)

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -217,6 +217,10 @@ export default defineConfig({
               text: 'LeXscroW',
               link: '/cyberdeals/lexscrow',
             },
+            {
+              text: 'cyberRaise',
+              link: '/cyberdeals/cyberraise',
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary
- document cyberRaise, MetaLeX's compliant fundraising dApp, under the cyberDeals umbrella
- link to cyberRaise from the cyberDeals index and navigation config

## Testing
- `./scripts/npm.sh test`


------
https://chatgpt.com/codex/tasks/task_e_6892809941088332aac98ad534deec01