### PR TITLE
docs: add governance adapters helpers and hooks

### DIFF
--- a/docs/pages/borg/borg-core.mdx
+++ b/docs/pages/borg/borg-core.mdx
@@ -32,5 +32,5 @@ The contracts can then be deployed with your preferred tooling.
 
 ## Next Steps
 
-Learn about [BORG modes](/borg/borg-modes), [conditions](/borg/conditions), and [implants](/borg/implants) to customize how your organization operates.
+Learn about [BORG modes](/borg/borg-modes), [conditions](/borg/conditions), [governance adapters](/borg/governance-adapters), [helpers](/borg/helpers), [hooks](/borg/hooks), and [implants](/borg/implants) to customize how your organization operates.
 

--- a/docs/pages/borg/governance-adapters.mdx
+++ b/docs/pages/borg/governance-adapters.mdx
@@ -1,0 +1,15 @@
+---
+showOutline: false
+content:
+    width: 75%
+---
+
+# Governance Adapters
+
+Governance adapters bridge borgCORE with external DAO governance systems, allowing a BORG to route proposals through specialized voting contracts.
+
+- [`baseGovernanceAdapater.sol`](https://github.com/MetaLex-Tech/borg-core/blob/main/src/libs/governance/baseGovernanceAdapater.sol) – abstract interface that defines common methods for creating, executing, and cancelling proposals and for retrieving vote totals.
+- [`flexGovernanceAdapater.sol`](https://github.com/MetaLex-Tech/borg-core/blob/main/src/libs/governance/flexGovernanceAdapater.sol) – implementation that connects to Flexa DAO's FlexGov contract and exposes proposal and vote management tailored to that system.
+
+These adapters let developers plug borgCORE into different governance frameworks without modifying the core contract itself.
+

--- a/docs/pages/borg/helpers.mdx
+++ b/docs/pages/borg/helpers.mdx
@@ -1,0 +1,12 @@
+---
+showOutline: false
+content:
+    width: 75%
+---
+
+# Helpers
+
+Utility contracts used across borgCORE live in the helpers library.
+
+- [`signatureHelper.sol`](https://github.com/MetaLex-Tech/borg-core/blob/main/src/libs/helpers/signatureHelper.sol) – verifies signatures for Gnosis Safe transactions. It reconstructs the Safe's EIP-712 transaction hash, recovers signer addresses, and returns the set of signers up to the Safe's threshold.
+

--- a/docs/pages/borg/hooks.mdx
+++ b/docs/pages/borg/hooks.mdx
@@ -1,0 +1,16 @@
+---
+showOutline: false
+content:
+    width: 75%
+---
+
+# Hooks
+
+Hooks enable BORGs to run custom logic after key lifecycle events such as Safe recovery.
+
+- [`baseRecoveryHook.sol`](https://github.com/MetaLex-Tech/borg-core/blob/main/src/libs/hooks/baseRecoveryHook.sol) – ERC‑165 compliant base contract that defines the `afterRecovery` hook.
+- [`exampleRecoveryHook.sol`](https://github.com/MetaLex-Tech/borg-core/blob/main/src/libs/hooks/exampleRecoveryHook.sol) – minimal implementation emitting a `RecoveryHookTriggered` event when invoked.
+- [`exampleRecoveryHookRevert.sol`](https://github.com/MetaLex-Tech/borg-core/blob/main/src/libs/hooks/exampleRecoveryHookRevert.sol) – sample hook that deliberately reverts, illustrating how hooks can halt the recovery process.
+
+Developers can extend these contracts to integrate their own post-recovery behavior.
+

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -84,6 +84,18 @@ export default defineConfig({
               link: '/borg/conditions',
             },
             {
+              text: 'Governance Adapters',
+              link: '/borg/governance-adapters',
+            },
+            {
+              text: 'Helpers',
+              link: '/borg/helpers',
+            },
+            {
+              text: 'Hooks',
+              link: '/borg/hooks',
+            },
+            {
               text: '📋 BORG Types',
               collapsed: true,
               items: [


### PR DESCRIPTION
## Summary
- document governance adapters with links to FlexGov and base adapter
- add helpers page for signature verification helper
- describe recovery hooks and sample implementations

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896500ddb788332bb30a169e4c65a23