### PR TITLE
Add MetaLeX ecosystem FAQ and navigation link

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -1,0 +1,399 @@
+# MetaLeX Ecosystem FAQ
+
+## What is MetaLeX and what does it aim to achieve?
+MetaLeX is a platform that fuses law and code to bring legal contracts, organizational governance, and financial deals onto the blockchain. It provides the infrastructure to turn traditional legal entities into cybernetic organizations where on-chain smart contracts handle decisions and transactions that previously relied on paper or manual processes. By combining autonomous blockchain technology with robust legal frameworks, MetaLeX helps communities coordinate and transact with greater speed, transparency, and trust‑minimization while remaining legally compliant.
+
+MetaLeX’s mission is to bridge the gap between legal agreements ("wet" contracts) and "dry" code. In the short run, the team focuses on improving efficiency, compliance, and access to justice by embedding smart contracts into legal and governance processes. In the long run, MetaLeX envisions empowering new cyber‑societies that enhance human freedom and prosperity by making legal, governance, and deal‑making functions autonomous and blockchain‑based. This means creating an "internet of agreements" where on-chain code executes and enforces agreements seamlessly in tandem with legal intent. In summary, MetaLeX’s goal is to make legal automation a reality – using code to enforce rights and obligations while ensuring those actions are recognized and enforceable under traditional law.
+
+## How is MetaLeX structured? What is MetaLeX OS and its modular architecture?
+MetaLeX is built as a modular, composable "operating system" for on-chain organizations, often referred to as MetaLeX OS (also called BORGs OS). This framework is composed of interchangeable smart contract components and legal templates that users can mix and match to fit their needs.
+
+At a high level, MetaLeX OS includes several layers:
+
+- **BORGs** – Cybernetic organizations that combine legal entity structures with on-chain governance via smart contracts. BORGs are the fundamental units, similar to traditional companies or foundations augmented with blockchain automation.
+- **cyberCORPs** – On-chain corporate structures that facilitate fundraising and equity/token issuance for startups. These are tech‑augmented corporate entities used for compliant capital raises with tokenized securities.
+- **cyberDeals** – A suite of smart contract tools for executing deals and agreements on-chain, such as escrows, vesting schedules, and automated legal contracts.
+- **Cybernetic Law Templates** – Legal contract templates designed to work hand‑in‑hand with code, ensuring that every on‑chain action has an associated legal text.
+
+MetaLeX OS is open-source and composable – new modules can plug into the system, and existing ones can be upgraded or configured without starting from scratch. The core contracts use a modular design with pluggable extensions called "implants" (smart contract modules that add specific features). Because of this design, MetaLeX components are often described as "LEGO blocks" for legal engineering.
+
+One key piece of the architecture is the **borgCORE** – essentially the heart of every BORG entity. The BORG Core contract wraps a Gnosis Safe (multisig wallet) with a policy layer and the standard DAO interface (ERC‑4824), enforcing which actions the multisig can take and under what conditions. The core is deployed in a chosen mode (whitelist, blacklist, or unrestricted) and then extended by various modules:
+
+- **BorgAuth** – an access control sub‑module deciding who can update policies or install new modules into the BORG.
+- **Condition Manager** – a component for checking custom on-chain conditions (like time locks or oracle feeds) before allowing certain actions.
+- **On-chain References** – storage in the core for pointers to legal documents (e.g., IPFS hashes of contracts) or links to an associated DAO’s data.
+- **Implants** – pluggable Safe modules that add features (like token vesting, optimistic approvals, emergency recovery, etc.) to a BORG.
+
+Because of this layered design, MetaLeX’s architecture is highly composable. You might deploy a base BORG Core for your organization, then attach a ConditionManager to enforce rules, add an implant for special grant-making logic, integrate a Cybernetic Agreement template for legal backing, and so on. Each piece focuses on a specific aspect (governance permissions, deal execution, compliance, etc.), and together they form a cohesive "operating system" for blockchain‑based legal entities.
+
+## What is a BORG, and how is it different from a DAO?
+BORG stands for "cyBernetic ORGanization" – a term MetaLeX uses for entities that combine a legal company structure with autonomous code. A BORG is essentially a traditional legal entity (like an LLC, corporation, foundation, etc.) whose charter includes built‑in rules delegating some decisions to smart contracts or AI. In other words, a BORG is a legal entity augmented by on-chain code.
+
+BORGs typically fall into two categories:
+
+- **Business BORGs (bizBORGs)** – Tech‑augmented companies that operate for profit. For instance, a startup could incorporate as a normal company but use tokenized shares, on-chain voting, and automated compliance.
+- **DAO‑Adjacent BORGs** – Entities that work alongside decentralized communities (DAOs) to handle things a purely on-chain DAO might struggle with (like legal agreements or holding real-world assets). These might be foundations or trusts that have some autonomy but ultimately serve a DAO’s interests under strict checks and balances.
+
+Compared to a traditional DAO, a BORG is not fully decentralized or anonymous. DAOs in the purest sense are entirely on-chain and self-governing by token holders, without legal entity status. BORGs, however, have legal incorporation and often a known management structure (directors, guardians). The key idea is that BORGs strike a balance: they maximize the use of trust‑minimized code and open governance where feasible, but plug in legal mechanisms wherever needed to cover edge cases or off‑chain obligations. They allow DAOs to accomplish things like signing contracts, hiring people, or owning assets in a legally recognized way while using smart contracts to automate and control those activities.
+
+## What is the BORG Core contract?
+The BORG Core (borg-core) is the primary smart contract that powers every MetaLeX BORG. It’s the on-chain brain or policy engine of the organization. Technically, BORG Core is implemented as a Gnosis Safe guard module combined with a DAO interface (ERC‑4824). This means it sits on top of a multisig wallet and intercepts or governs what that multisig can do, according to the BORG’s rules.
+
+Key aspects of BORG Core include:
+
+- **Modes** – When deploying a BORG Core, you choose an immutable mode: whitelist, blacklist, or unrestricted. In whitelist mode, only explicitly allowed actions can be done by the Safe; in blacklist, all actions are allowed except those forbidden; unrestricted mode applies minimal checks.
+- **Policy Checks** – The core enforces policy via various sub-components. The Condition Manager evaluates any conditions set on actions, requiring that specific conditions (time delays, approvals, external data conditions, etc.) are true before a transaction is executed.
+- **BorgAuth (ACL)** – An access control layer defining who is allowed to make administrative changes to the BORG, typically giving permission to a DAO governance contract or a council rather than individual Safe signers.
+- **Implant Support** – The core supports implant modules, additional contracts that extend Safe functionality, such as token vesting or emergency recovery.
+- **Legal & DAO Linkage** – The BORG Core stores references to off-chain legal documents and can store the identifier of an associated DAO, tying legal and technical aspects together.
+
+In practice, BORG Core enforces the “rules of the game” inside a BORG. If the Safe is the vault holding assets, the BORG Core is the guard at the vault’s door, checking every instruction against the rulebook. Once deployed, its mode can’t be changed, providing confidence that the BORG will operate only as authorized.
+
+## What is the ConditionManager and why is it important?
+The ConditionManager is a module in the MetaLeX system that allows a BORG to enforce complex, custom rules (conditions) on actions taken by its contracts. It lets you specify that an action can occur only if certain conditions are met, encoding real‑world governance or legal requirements into smart contracts.
+
+How it works:
+
+- The ConditionManager keeps a list of condition contracts and knows how to evaluate them in logical combinations. Each Condition is a separate smart contract that returns true/false under certain circumstances.
+- Multiple conditions can be combined with AND or OR logic, allowing sophisticated requirements.
+- Conditions can be global (apply to all operations) or function-specific.
+- Conditions are modular; authorized roles can add or remove condition contracts over time as needs change.
+- When an action is attempted, the ConditionManager checks the relevant conditions and reverts the transaction if any required condition is not met.
+
+This enables on-chain code to reflect real‑world rules and safeguards, such as requiring both a majority approval and a time delay before a payout occurs.
+
+## What is the SignatureRegistry (or Cyber Agreement Registry) and what does it do?
+The SignatureRegistry, also referred to as a Cyber Agreement Registry, tracks the signing of legal agreements on-chain. Deals between parties often involve both an on-chain transaction and an associated legal document. The SignatureRegistry keeps a tamper-proof record of who signed an agreement, when they signed, and whether all required parties have signed.
+
+For each legal template, the registry stores a template ID and a reference to the legal text. When a new deal is created, an entry is created linking to the template and recording the participating parties. As each party digitally signs the agreement, the registry logs the signature and timestamp. It can determine if an agreement is fully signed by comparing collected signatures to the number of required parties and can emit an event once all have signed.
+
+This functions as an on-chain notary and ledger for agreements, ensuring no action is taken without proper authorization from each party and providing evidence that can be used off-chain if needed. The registry often works with other modules; for example, a BORG might require a SignatureRegistry entry to be fully signed before executing an action.
+
+## What is LeXscroW and how does it work?
+LeXscroW is MetaLeX’s on-chain escrow system – a set of smart contracts that hold funds or assets in trust and only release them when predetermined conditions are met. Once a LeXscroW contract is created, no one can arbitrarily take the funds; the logic automatically executes the agreed outcome or refunds participants if conditions fail.
+
+Key features include:
+
+- **Trust-minimized & Non-custodial** – Assets are held in a smart contract with no owner; only the coded conditions control their release.
+- **Immutable Conditions** – Rules for release are set at creation and cannot be changed, giving participants certainty.
+- **Automatic Refunds** – If conditions are not met, participants can reclaim their deposits.
+- **Flexible Deposits & Participation** – Contracts can allow open participation or restrict deposits to specific addresses.
+- **Composable** – LeXscroW can be combined with other MetaLeX tools for complex deals.
+
+Variants include DoubleTokenLeXscroW for token swaps, TokenLeXscroW for one-way deals, and EthLeXscroW for native currency escrows. Typical use cases include trustless token swaps, milestone-based funding, grants with clawback, and conditional payouts.
+
+## What is LeXcheX and what does it do?
+LeXcheX is MetaLeX’s on-chain accredited investor verification service. It lets an investor prove they are an accredited investor entirely on the blockchain and receive a tamper-proof NFT certificate as proof, replacing traditional paperwork-heavy processes.
+
+How it works:
+
+1. **Investor Questionnaire** – The user answers questions about how they qualify as accredited.
+2. **On-Chain Asset Check** – An off-chain oracle evaluates the investor’s wallet balances to confirm asset thresholds.
+3. **On-Chain Legal Agreement & NFT Issuance** – If the check is successful, the investor signs an attestation and pays a fee, and LeXcheX mints a non-transferable NFT certificate to the wallet.
+
+Projects like cyberRaise can require this NFT before allowing participation, ensuring compliance with regulations like U.S. Rule 506(c). The NFT is issued under attorney oversight and can expire or be revoked, providing accountability.
+
+## What is MetaVesT and how is it used?
+MetaVesT is an advanced token vesting and lockup protocol. It handles complex token distribution schedules in a trust-minimized way, mirroring terms found in traditional equity grants or token sale lockups.
+
+Capabilities include:
+
+- Dual vesting and unlock curves, tracking when tokens are earned and when they become transferable.
+- Optional cliffs on either curve.
+- Token options and 83(b) support via exercise prices.
+- Group amendments allowing majority-in-value of grantees plus the grantor to amend terms.
+- Can’t-be-evil protections preventing arbitrary clawbacks of vested tokens.
+- Pass-through voting, allowing locked tokens to participate in governance.
+- Milestone-based vesting triggered by external events.
+
+MetaVesT escrows tokens and issues non-transferable receipt tokens to grantees. As time passes or milestones occur, the contract updates vested and unlocked amounts. Grantees can withdraw tokens that are both vested and unlocked. MetaVesT is ideal for team/investor vesting, DAO grants, investor lock-ups, and complex deal structures.
+
+## What is a Ricardian Tripler?
+A Ricardian Tripler tightly binds together three elements of an agreement – the code, the legal text, and the parameters – into one package. Parties sign one on-chain transaction that records the parameters, stores the legal text, and deploys or references the smart contract enforcing the deal, linking all three components.
+
+This synchronization ensures the legal document explicitly references the smart contract, and the smart contract is parameterized exactly as described in the legal text. The concept prevents disputes where code and human intent diverge and is a step toward "lex cryptographia," where code and law function as one.
+
+## What is the GAIB Agent and what off-chain computation does it handle?
+The GAIB Agent is an off-chain computational agent or oracle service that performs tasks too complex or impossible to do entirely on-chain. It interacts with MetaLeX smart contracts to provide trusted off-chain inputs or computations.
+
+Examples include:
+
+- Evaluating crypto asset holdings for LeXcheX accreditation checks.
+- Fetching external data feeds like prices or court decisions.
+- Running heavy computations or AI analyses and posting results on-chain.
+- Generating zero-knowledge proofs or other verifiable data for on-chain use.
+
+The GAIB Agent extends MetaLeX contracts beyond blockchain limits while minimizing trust by using legal accountability or cryptographic proofs.
+
+## How does MetaLeX integrate legal contracts with smart contracts?
+MetaLeX practices "Legal Engineering," deliberately designing legal agreements and software together so they operate as a cohesive system. Integration is achieved through:
+
+- **Cybernetic Law Templates** that reference on-chain elements and have slots for on-chain data.
+- **On-chain storage of agreements** via the Cyber Agreement Registry, enabling reconstruction of the full contract from template and parameters.
+- **Ricardian Triplers** that align legal text and code.
+- **No closed platforms** – agreements and data are open and composable.
+- **Automation of execution** through smart contracts, minimizing reliance on human performance.
+- **Fallbacks and edge cases** addressed via legal clauses when code cannot handle a scenario.
+- **Enforceability** by ensuring courts can reference on-chain records as the agreed source of truth.
+
+This approach merges human language and programming language, making legal automation possible.
+
+## Who are the intended users of MetaLeX, and what are some real use cases?
+MetaLeX serves several groups:
+
+- **Web3 Startup Founders & Projects** – Use cyberCORPs, cyberRaise, LeXcheX, and MetaVesT to raise funds and manage governance.
+- **DAOs and Decentralized Communities** – Use DAO-adjacent BORGs for grants, security, or IP management while retaining on-chain transparency and control.
+- **Investors** – Gain clear, automated records of their rights via NFTs and trust in escrowed funds.
+- **Legal Professionals and Advisers** – Leverage MetaLeX templates and modules to build solutions for clients.
+- **Community Members & DAO Token Holders** – Benefit from transparent operations and safeguarded funds.
+
+Real examples include the Neutron Grants BORG, cyberRaise fundraising rounds, DAO-to-DAO collaborations using LeXscroW, and compliance/KYC scenarios using credential NFTs.
+
+## How is MetaLeX governed, and what is the plan for decentralization of the platform?
+MetaLeX is currently developed by MetaLeX Labs, but the architecture is open and increasingly community-driven. The BORGs OS is open-source, and the community contributes via documentation, templates, and feedback. The cyberCORP initiative is in a controlled beta, with plans to open up as legal frameworks mature.
+
+Future decentralization may involve launching a MetaLeX DAO or foundation to oversee protocol upgrades, curating templates, and possibly introducing a token for governance and incentives. The roadmap likely includes open-sourcing remaining components, completing audits, and establishing community governance once the platform is stable and compliant.
+
+## How does MetaLeX address compliance and regulatory considerations?
+Compliance is central to MetaLeX’s design:
+
+- **Legal Entity Wrappers** provide limited liability and clarify tax and reporting duties.
+- **Securities Law Compliance** is baked in through modules like cyberRaise and LeXcheX, enabling Reg D and Reg S offerings with automated checks.
+- **Embedded Compliance Checks** use conditions to enforce investor caps, jurisdiction limits, and more.
+- **KYC/AML Integration** is possible via credential NFTs or third-party oracles.
+- **Data Privacy** is respected by only storing necessary data on-chain and exploring privacy-preserving techniques.
+- **Jurisdictional Customization** allows templates and modules tailored to different legal regimes.
+- **Transparency and Auditability** ensure regulators or auditors can verify operations directly on-chain.
+- **Emergency Mechanisms** like FailSafe implants provide lawful intervention paths without undermining decentralization.
+
+This proactive approach lets projects comply with regulations while leveraging blockchain advantages.
+
+## Does MetaLeX have a token? How does the MetaLeX platform sustain itself?
+As of now, MetaLeX does not have a public native token. The platform’s economic model revolves around providing services and charging fees, such as the $100 USDC fee for LeXcheX accreditation certificates. MetaLeX Labs may also offer consulting or enterprise services for revenue.
+
+If a MetaLeX token is introduced in the future, it could serve governance, incentivize network participants, or capture value from platform usage. Any such token would likely be designed carefully to remain compliant with securities regulations. Until then, MetaLeX focuses on building a robust platform and user base through service-based sustainability.
+
+## How secure is MetaLeX? What is the security model and audit status?
+MetaLeX prioritizes security through:
+
+- **Proven Building Blocks** like Gnosis Safe for asset custody.
+- **Least Privilege and Role Separation** via directors, guardians, and DAO oversight.
+- **Non-Custodial Design** for modules like LeXscroW and MetaVesT.
+- **Extensive Testing and Audits** by firms such as MixBytes and Zellic for major components.
+- **Ongoing Security Monitoring** and potential bug bounty initiatives.
+- **Upgrade Safety** through multi-party approval and time delays where applicable.
+- **Fail-safes** like DeadManSwitchCondition and FailSafe implants for recovery scenarios.
+
+To date, MetaLeX has undergone multiple independent audits with no major security incidents reported, reflecting a strong commitment to safeguarding user assets and legal agreements.
+
+## FAQ – Legal, Regulatory, and Practical Concerns (for Professionals & Skeptics)
+
+This section addresses advanced questions raised by legal professionals, regulators, institutional investors, and experienced users who are scrutinizing MetaLeX’s approach. It provides legally grounded, practical answers to common doubts about MetaLeX’s cybernetic agreements, on-chain legal enforceability, regulatory compliance, and real-world usability.
+
+### Q: Are MetaLeX’s “cybernetic” on-chain agreements actually enforceable in the real world?
+
+A: Yes. MetaLeX contracts are designed to be legally binding dual agreements – every on-chain action is mirrored by a written legal contract. When parties enter a MetaLeX deal, a smart contract executes on-chain and the human-readable legal terms (stored on IPFS) are simultaneously adopted, with the transaction data populating the contract text
+GitHub
+GitHub
+. In effect, signing a MetaLeX transaction from your wallet is also cryptographically signing a conventional agreement. This Ricardian Tripler approach ties code, legal text, and parameters into one package, ensuring the smart contract’s outcomes align exactly with the legal obligations
+GitHub
+. Because the legal agreements explicitly reference the specific smart contract address and terms, a court or arbitrator can recognize and enforce them if a dispute arises. The records on blockchain (signatures, timestamps, parameters) serve as tamper-proof evidence of the deal’s terms and each party’s commitments. In short, MetaLeX replaces “paper-only” contracts with hybrid code-and-prose contracts – they self-execute on-chain, but remain backed by traditional legal validity (e.g. offer, acceptance, and intent to be bound), giving professionals the assurances of enforceability they expect.
+
+### Q: What if something goes wrong on-chain – say a bug, an exploit, or a disagreement about a MetaLeX contract’s outcome? Do we still have recourse?
+
+A: MetaLeX is built to handle disputes and unforeseen issues by combining automated enforcement with legal fallback mechanisms. First, MetaLeX tries to prevent disputes: the smart contracts are rigorously tested and often audited, and their behavior is transparent to all parties
+GitHub
+. But if a problem does arise (for example, a counterparty breaches an obligation or a critical bug affects the outcome), the parties are not left helpless. Because there is a parallel legal agreement for every deal, an aggrieved party can pursue remedies through normal legal channels – such as arbitration or court litigation – using the signed contract text and blockchain records as evidence. Importantly, MetaLeX’s chosen legal frameworks support this: for instance, the Cayman Islands (where many MetaLeX “BORG” entities are registered) offers specialized courts and a body of common-law precedent for complex business disputes, providing a knowledgeable forum if on-chain agreements end up in litigation
+GitHub
+. In practice, many MetaLeX contracts include built-in dispute resolution clauses (e.g. arbitration provisions or choice-of-court agreements) to ensure there’s a clear path to resolve issues off-chain if purely on-chain resolution isn’t possible.
+
+MetaLeX’s philosophy is “trust the code for determinable outcomes, but have law as a safety net.” The system strives for lex cryptographia – where code handles routine execution and only ambiguous or wrongful situations fall back to legal processes
+GitHub
+. Day-to-day, the smart contracts and DAO governance automate decisions, but if something like a hack or an irreconcilable disagreement occurs, human legal norms re-enter to provide accountability. The bottom line for skeptical professionals: you gain the efficiency and certainty of self-executing code without giving up the ability to sue, obtain injunctions, or otherwise enforce rights through the courts when needed. MetaLeX’s own legal team (which even includes former regulatory attorneys familiar with dispute scenarios
+metalex.tech
+) has engineered the framework so that no on-chain action is beyond the reach of law.
+
+### Q: MetaLeX uses Cayman foundation companies and other offshore entities as legal wrappers. Is this just regulatory arbitrage? What about jurisdiction mismatches if participants are worldwide?
+
+A: The use of jurisdictions like the Cayman Islands is intentional – not to evade law, but to provide a neutral, crypto-friendly legal home that aligns with DAO principles. Cayman “foundation companies” in particular have features ideally suited for decentralized projects: they have no shareholders or private owners, can be structured with purely charitable or mission-based purposes, and allow bylaws that hardwire DAO governance into the entity
+GitHub
+GitHub
+. This means a BORG (cybernetic organization) based in Cayman is ownerless (much like a DAO) and exists solely to carry out its stated purpose (e.g. supporting a protocol), rather than to maximize shareholder profit
+GitHub
+. By anchoring the organization in one well-defined jurisdiction, MetaLeX avoids the chaos of every multisig signer’s local laws applying at once
+GitHub
+. All participants know which law governs the entity – providing certainty and avoiding, say, a scenario where a globally distributed team accidentally creates an “unincorporated partnership” subject to dozens of countries’ regulations
+GitHub
+.
+
+Far from being a shady haven, the Cayman Islands currently offers a robust but innovation-friendly regulatory environment. It has no hostile DAO-specific rules, and its regulators and service providers are experienced with crypto entities. In fact, Cayman foundations come with accountability measures (like requiring a local Supervisor if there are no members) that MetaLeX leverages to ensure compliance with the entity’s rules
+GitHub
+. This choice of jurisdiction also preempts certain U.S. regulatory issues – for example, by isolating potentially investment-like activities in a Cayman foundation, a DAO can avoid being viewed by U.S. authorities as an unregistered investment fund
+GitHub
+. That said, MetaLeX is not about hiding from regulation: if a MetaLeX-structured entity operates in other countries (e.g. hiring a U.S. team or serving U.S. investors), it still must comply with those local laws (securities law, tax law, etc.). The Cayman wrapper simply gives a solid legal base; from there, additional compliance (like U.S. securities exemptions, filings, KYC/AML for investors, etc.) can be layered as needed for activities in other jurisdictions. In summary, MetaLeX’s legal strategy is to choose the right tool for the job – e.g. Cayman for a global DAO foundation, Delaware for a U.S.-based non-profit subsidiary – to ensure the entity is both legally sound and aligned with decentralization, rather than to dodge oversight.
+
+### Q: Could these legal wrappers (BORGs) be abused or have vulnerabilities? For instance, what stops a BORG’s insiders from misusing funds or power?
+
+A: MetaLeX BORGs are specifically designed to minimize the risk of insider abuse through both legal obligations and technical safeguards. Legally, every participant in a BORG (e.g. a multisig signer or board member) must sign a BORG Participation Agreement that binds them to act in the entity’s interest and follow its bylaws
+GitHub
+. This creates a direct contractual duty – if a signer attempted to misappropriate assets or act outside their authority, the foundation (via its Supervisor) and even the DAO community (as third-party beneficiaries) would have legal grounds to hold that individual accountable in court
+GitHub
+. In other words, rogue actors face real liability for breaching their duties, which deters bad behavior beyond just the honor system.
+
+On the technical side, MetaLeX hard-codes compliance into the smart contracts. The BORG’s on-chain multi-signature wallet (typically a Gnosis SAFE) is outfitted with MetaLeX’s custom “BorgOS” extensions that act as automated watchdogs
+GitHub
+. For example, the core BORG smart contract serves as a Guard on the SAFE, whitelisting only the actions that are allowed per the BORG’s legal charter
+github.com
+. Any transaction that isn’t pre-approved (by type, amount, recipient, etc.) will be blocked by the contract guard
+github.com
+. This means that even if all human signers colluded to do something unauthorized (like sending funds to a personal address or doing an out-of-scope investment), the on-chain code would prevent it unless the proper DAO approvals or conditions are satisfied. MetaLeX’s Condition Manager can even enforce that certain actions only execute if an oracle or external condition is met (for instance, requiring an on-chain vote outcome or a price feed reading)
+github.com
+. Additionally, BORG bylaws themselves explicitly state that any asset moved outside the approved on-chain channels isn’t legally recognized – a rogue signer moving funds “off-book” would be violating bylaws and could be sued for breach of fiduciary duty
+GitHub
+GitHub
+.
+
+To summarize, power in a BORG is tightly circumscribed: human actors are constrained by both the threat of legal action and by code that enforces the rules in real time. The MetaLeX approach delivers a “defense in depth”: if someone somehow bypasses a smart contract control, the legal agreements kick in; and if someone tries to shrug off legal duties, the smart contracts are there to stop unauthorized moves. This dual layer of protection greatly mitigates the risk of misuse or malfeasance compared to an unstructured DAO or a traditional company without such integrated controls.
+
+### Q: MetaLeX claims legal compliance and “bridging law and code.” How do we know this isn’t just superficial? Is the compliance truly substantive?
+
+A: It’s absolutely substantive. MetaLeX was founded by seasoned attorneys and engineers specifically to embed real legal rigor into blockchain systems – not as a marketing checkbox, but as the core of the platform
+metalex.tech
+. Every BORG or cybernetic contract MetaLeX helps create involves real legal work: drafting bespoke charters and bylaws, coordinating with law firms to register entities, and ensuring ongoing compliance. For example, when spinning up a BORG foundation, MetaLeX works with licensed Cayman counsel to formally register the company and draft its Memorandum & Articles and Bylaws in line with the DAO’s needs
+GitHub
+. They even arrange professional directors or supervisors when required by local law, and strictly limit those roles via legal documents to prevent any loopholes
+GitHub
+. All of this is far beyond a token “paper filing” – it’s a complete legal architecture backing the on-chain operations.
+
+Moreover, MetaLeX’s smart contracts and legal documents are developed in tandem. The team’s lawyers and developers iterate together so that the bylaws and code reflect each other precisely
+GitHub
+GitHub
+. This includes defining clear processes for things like adding members, transferring tokens, or dissolving the entity, and then implementing those processes both in the legal text and in the solidity code. The goal is that anyone examining a MetaLeX structure can see that the rules aren’t just on paper: they are actively enforced by software. For instance, if the bylaws say “any change to the BORG’s multisig signers requires DAO approval,” the smart contract guard literally will not allow a new signer to be added unless a verified DAO vote has occurred
+GitHub
+. This kind of cross-verification shows that compliance is built into the system’s operations, not merely its intentions.
+
+Finally, MetaLeX’s commitment to real compliance is evidenced by the projects and communities involved. Major DAO initiatives (such as the Lido community’s “Lido Alliance” foundation and others) have used MetaLeX’s framework, subjecting it to scrutiny by top law firms and DAO contributors. The fact that sophisticated stakeholders are adopting BORG structures indicates trust that these are legally sound, not just empty shells. Even MetaLeX’s experimental features like GAIB (an AI legal agent) have detailed legal safeguards (e.g. a Delaware non-profit wrapper, purpose clauses, etc.) rather than being freewheeling bots
+followin.io
+followin.io
+. In sum, MetaLeX’s value proposition hinges on actual legal enforceability and compliance – something they’ve architected at every level of the stack.
+
+### Q: MetaLeX relies on off-chain data and “GAIB” AI agents in some cases. Doesn’t that reintroduce trust and uncertainty? How is the oracle/agent model handled?
+
+A: MetaLeX minimizes off-chain dependencies, but when they are necessary, it handles them in a transparent and trust-managed way. Oracles (for feeding external data like prices or events) and the GAIB agent (MetaLeX’s AI legal assistant) are integrated with careful checks and balances. Here’s how:
+
+- **Decentralized & Controlled Oracles** – MetaLeX smart contracts can ingest off-chain information via oracle feeds, but these are never a single point of failure. The BORG’s Condition Manager module allows multiple conditions and approvals to be required for any action
+github.com
+. For example, a payment might require both an oracle price and a DAO multisig approval to proceed, ensuring no oracle alone can trigger a critical transaction. Oracles can be chosen from reputable decentralized networks (like Chainlink or similar) or even a consortium of known data providers. The oracle inputs themselves are often anchored in the legal docs – the agreement will specify the data source and what happens if that source fails. This way, everyone knows which off-chain data is authoritative, and there’s a legal basis to disregard data that falls outside defined parameters (e.g. clearly erroneous feeds could be deemed invalid by contract). In short, off-chain data is brought in only with explicit, verifiable mechanisms, and usually requires human or DAO sign-off for anything consequential.
+
+- **GAIB (Governance AI Bot) with BORG Oversight** – The GAIB agent – essentially an AI programmed to assist with legal research or even sign certain low-risk transactions – is not a free-roaming AI without constraints. In fact, the GAIB agent is itself wrapped inside a MetaLeX BORG entity (in this case, a Delaware nonstock non-profit corporation) to impose legal and governance oversight
+followin.io
+. The GAIB BORG’s charter includes a “Qualified Code is Law” provision: most of the time the AI’s on-chain actions (its “code”) are treated as the final word, except in defined edge cases like obvious malfunctions or hacks
+followin.io
+. This means if the GAIB agent operates normally (e.g. reviewing a smart contract and giving a green light within its authority), its decisions can auto-execute on-chain. But if it behaves abnormally – say due to an AI glitch or it signs a clearly unauthorized transaction – the BORG’s rules allow human supervisors (and the DAO governance) to step in and override or unwind those actions
+followin.io
+. Practically, GAIB’s powers are limited: it might be allowed to co-sign routine transactions or provide on-chain legal opinions, but it cannot unilaterally control funds beyond what it’s been permitted. All of its transactions still go through the SAFE multisig (where other human or DAO signers can veto if something looks off). In essence, MetaLeX treats an AI agent like any other fallible actor – it’s given a role with specified permissions, and it’s sandboxed within a legal entity so that there’s always an accountable party if something goes wrong.
+
+By combining on-chain controls with off-chain legal oversight, MetaLeX ensures that oracle feeds and AI agents enhance autonomy without compromising trust. Users and regulators can inspect the logic (open-source code, oracle addresses, AI parameters) and also take comfort that an identifiable legal entity is responsible for the outputs. The trust model thus remains multi-layered: trust the math and code where you can, but also have human governance and legal accountability watching over any automated agents.
+
+### Q: Can MetaLeX-based organizations actually interact with traditional legal systems? For example, can a BORG own assets in the real world, sign contracts off-chain, or be taken to court?
+
+A: Absolutely. A MetaLeX “BORG” is a real legal entity (such as a foundation company or nonprofit corporation) and has all the capacities of any company in that jurisdiction. That means it can own property, intellectual property, and other assets in its own name, enter into contracts with outside parties, hire employees or contractors, and so on
+GitHub
+GitHub
+. For instance, a BORG’s foundation could hold a Web2 domain name or a patent on behalf of the DAO – something a smart contract alone cannot do – providing a crucial bridge between on-chain operations and off-chain property rights
+GitHub
+. Likewise, the BORG can open bank accounts or fiat on-ramp accounts if needed, because it has legal personhood (banks or vendors can KYC the entity and deal with it just like they would with an LLC or corporation).
+
+Importantly, a MetaLeX entity can also appear in court or arbitration as the vehicle representing the DAO’s interests. If the BORG needs to sue (or be sued), the case can be brought in the courts of its home jurisdiction (e.g. Cayman Islands court for a foundation, Delaware court for a U.S. nonstock corp). Those courts are perfectly capable of adjudicating disputes involving the entity’s bylaws or agreements – Cayman even has specialized business courts ready to handle complex crypto disputes
+GitHub
+. MetaLeX’s legal design ensures there’s always a designated agent or responsible director who can respond to legal service on the entity’s behalf, so a lawsuit won’t get stuck in a black hole. This interoperability extends to things like regulatory filings or registrations: for example, if a BORG issues tokenized shares or interests, it can maintain an official shareholder (member) register that mirrors the on-chain token holdings, satisfying company law requirements. In summary, MetaLeX entities are fully-fledged legal actors in the traditional sense, giving you the benefits of engaging with courts, registries, and counterparties, while concurrently operating with the efficiency of on-chain code.
+
+### Q: What if regulators (like the SEC in the U.S.) crack down on crypto activities? Are MetaLeX structures prepared for regulatory scrutiny or enforcement?
+
+A: MetaLeX is designed with regulatory compliance in mind, aiming to future-proof projects against exactly that kind of risk. By blending legal entities with on-chain governance, MetaLeX actually makes it easier to demonstrate compliance to regulators. For example, if a DAO purely exists on-chain with no legal wrapper, a regulator like the SEC might view it as an unincorporated association or even attempt to treat token holders as part of a de facto partnership – a nightmare scenario. MetaLeX avoids this by giving the DAO a recognized legal form (like a foundation or nonprofit) which regulators can engage with. The foundation can clarify roles (it’s clear who the directors are, who to contact), and it can implement compliance measures (it might restrict token sales to accredited investors, or file disclosures, etc., if required). Essentially, MetaLeX provides an accountability layer that regulators typically want to see
+forum.zknation.io
+.
+
+Furthermore, MetaLeX structures are intentionally crafted to steer clear of the most sensitive regulatory red flags. For instance, if a BORG will be handling community funds or investments, MetaLeX will structure it so that the foundation is non-profit and has no equity owners, making it less likely to be deemed a security issuer or an “investment company”
+GitHub
+GitHub
+. Profits are not distributed to individuals; instead, any funds are used for the DAO’s purposes, which helps avoid classifications like securities dividends. In one real example, the GAIB project’s token (GAIB) was explicitly not sold as an investment – the token proceeds go into a decentralized liquidity pool, not to MetaLeX or any company’s coffers
+followin.io
+. This kind of setup was chosen so that the token functions as a utility/governance token for the AI agent, not as a share of a business
+followin.io
+. By proactively structuring offerings and entities in compliant ways (with legal guidance from experts, including ex-SEC personnel on the MetaLeX team
+metalex.tech
+), MetaLeX greatly reduces the risk of running afoul of regulations.
+
+Of course, no structure is immune to regulatory overreach or changing laws. However, if a regulator does raise an issue, a MetaLeX BORG can respond in a formal, cooperative manner – it can hire counsel, negotiate, or implement remedial measures as needed, just like any company. Importantly, having clear bylaws and records means a MetaLeX entity can demonstrate its good-faith compliance (for example, showing a regulator the provisions that ensure token holders had to be verified, or that a DAO vote was required for certain actions, etc.). This transparency and built-in compliance make it far easier to satisfy regulators compared to an unaffiliated DAO. In summary, MetaLeX can’t guarantee that a given project won’t become subject to regulation, but it provides the tools to be compliant from day one and to adapt swiftly if the legal environment shifts.
+
+### Q: In a MetaLeX multi-signature governance setup, who owns the IP or products created? And what about personal liability – are the multisig signers/directors personally on the hook if something goes wrong?
+
+A: Intellectual Property (IP) – MetaLeX ensures IP is owned or controlled by the legal entity (the BORG), not by the individual contributors. For example, if a team of developers within a BORG creates software or a brand, the Cayman foundation or Delaware corporation can hold the copyright or trademark. MetaLeX’s framework explicitly allows the entity to custody legal rights and IP that a smart contract can’t hold
+GitHub
+. In practice, MetaLeX often arranges for contributors to assign any created IP to the foundation, or grants the foundation a perpetual license to use it. A concrete case was the GAIB AI lawyer project: MetaLeX Labs granted the GAIB BORG a perpetual, royalty-free license to all the _gai16zbrielShapir0 AI’s intellectual property, to ensure the BORG (and by extension the community) can use the AI without risk of MetaLeX later revoking those rights
+followin.io
+. This kind of arrangement is essentially “IP escrow” – it prevents any one signer or even the founding team from monopolizing assets that are meant for the DAO’s benefit. All key assets (code, domain names, etc.) end up owned by the BORG or formally licensed to it, so they remain with the community’s vehicle even if individual people leave the project.
+
+Liability: One big advantage of the BORG legal wrapper is that it shields individual participants from personal liability in almost all normal circumstances
+GitHub
+. The foundation company or corporation is a separate legal person – it bears the brunt of any legal liability, debt, or lawsuit. Directors, officers, and multisig signers are generally not personally responsible for the entity’s obligations, as long as they are acting in good faith and in accordance with their duties
+GitHub
+. If, say, the BORG is sued or owes money, the plaintiffs can go after the foundation’s assets, not the personal assets of the multisig members. This limited liability is crucial for getting talented people to serve in these roles without fear of ruinous personal risk
+GitHub
+. Of course, the protection isn’t absolute: if a signer commits egregious wrongdoing – e.g. fraud or willful illegal activity – courts can “pierce the veil” and hold them personally accountable
+GitHub
+. But for ordinary negligence or business losses, the BORG structure provides a corporate veil just like a normal company.
+
+To further protect individuals and encourage responsible governance, all BORG signers explicitly agree to fiduciary-like duties in the Participation Agreement and bylaws
+GitHub
+GitHub
+. They must act in the best interest of the entity/DAO mission and not for personal gain
+GitHub
+. If they uphold those duties, they remain shielded by the entity. If they breach them (e.g. siphoning funds), then aside from legal action, they also lose the protection – a rogue signer would not only face potential lawsuit but could also be deemed acting outside their authority (and thus possibly personally liable). In summary, MetaLeX aligns incentives so that IP and value accrue to the entity/DAO, and contributors are protected when doing the right thing, but cannot secretly capture value or harm the project without serious consequences.
+
+### Q: How does MetaLeX handle edge-case failures, like a multisig stalemate (signers not agreeing or disappearing) or a critical smart contract bug locking up funds?
+
+A: MetaLeX anticipated these scenarios and built in safety valves at both the legal and smart-contract level. Here are a few ways edge cases are handled:
+
+- **On-Chain “Eject” and Signer Replacement** – If a multisig signer becomes uncooperative or incapacitated, MetaLeX’s BORG contracts allow for their removal or replacement. There is an Eject Implant module that, when enabled, lets an authorized party (often the DAO or a designated “Authority” address) remove a signer from the Gnosis SAFE, or lets a signer voluntarily resign on-chain
+github.com
+. Typically, the DAO (via a governance vote) would have to approve this action, preventing abuse. This ensures that if, for example, one signer disappears or refuses to sign anything (causing a stalemate), the community isn’t permanently stuck – they can vote to replace that keyholder and restore the BORG’s functionality.
+
+- **FailSafe Mechanisms** – MetaLeX BORGs also feature a FailSafe module to recover funds in emergencies
+github.com
+. The FailSafe can be configured with conditions such as timeouts or specific triggers. For instance, the BORG could stipulate: “If the multisig hasn’t had any activity in 6 months and XYZ conditions are met, then funds auto-transfer to the parent DAO’s treasury.”
+followin.io
+ This was implemented in the GAIB BORG: if the AI agent or its multisig fails to act for a defined period, the funds revert to a MetaLeX multisig as a backstop
+followin.io
+. FailSafes can also be triggered by a DAO vote or an oracle signal (like a “dead-man switch” condition) if something is clearly wrong. This means even if a contract upgrade is impossible or signers vanish, there’s a predefined way to claw assets back to safety.
+
+- **Legal Override for Catastrophic Events** – In the bylaws and contracts, MetaLeX often includes clauses covering force majeure or “code failure” scenarios. Essentially, the parties acknowledge that if an extreme unforeseen bug or hack occurs – something that defeats the intended functioning of the code – they will cooperate to fix it under the guidance of the DAO or through legal means. In the GAIB charter, for example, there’s a provision that “code is law” except in cases of obvious hacks or blockchain failures
+followin.io
+. Those exceptions allow the community to treat such events as void/unauthorized and to seek remedies (like deploying a patch contract, or in worst case, going to court to freeze misappropriated funds). Additionally, because the BORG is a legal entity, it could file an insurance claim (if there’s coverage) or take emergency actions like hiring a forensic team without needing a new DAO vote in the heat of the moment – it has enough legal agency to respond quickly when required.
+
+In essence, MetaLeX’s design acknowledges that despite best efforts, things can go wrong. By incorporating redundant controls – the ability to vote out a stuck signer, the ability to recover assets on timeout, and legal clauses for handling the truly unexpected – the system provides a path to recovery or resolution. These measures reassure stakeholders that a MetaLeX-based organization won’t be permanently paralyzed by a single point of failure. Even in edge cases, there are procedures to fall back on, governed by either on-chain consensus or legal processes, so the organization can adapt and continue rather than collapse.
+
+### Q: Could there be a conflict between what DAO token holders decide and what the BORG’s directors or signers are legally obligated to do? What if the DAO’s vote goes against the directors’ fiduciary duties or vice versa?
+
+A: MetaLeX’s entire approach is to align the DAO’s will with the legal entity’s duties as closely as possible, so direct conflicts are rare by design. The foundation documents of a BORG explicitly state that the entity’s purpose is to serve the DAO’s project and community
+GitHub
+. In legal terms, this means the directors’ primary “fiduciary duty” is effectively to carry out the DAO’s mission as defined in those documents. Thus, when a DAO vote is made in accordance with that mission (e.g. approving a budget or changing a protocol parameter), the BORG’s officers are actually fulfilling their duties by executing that decision. MetaLeX reinforces this alignment by embedding DAO oversight into the legal structure: many BORG bylaws include clauses that any major decisions require DAO approval (for example, adding a new board member or dissolving the entity must be voted on by token holders)
+GitHub
+. This legal requirement means the directors cannot take certain actions unilaterally even if they wanted to – the DAO’s decision is literally part of the corporate governance process, not just an informal influence. The software enforces the same; if bylaws say “DAO must approve X,” then the smart contracts will block action X until a DAO vote is confirmed on-chain
+GitHub
+. All of this ensures that in normal operations, there’s no divergence: the DAO’s vote and the directors’ legal obligations point in the same direction.
+
+Now, consider a scenario where a DAO passes a proposal that might be problematic – say, something outside the BORG’s legal purpose or even illegal. Because the directors are real people with legal duties, they cannot blindly follow a DAO instruction that is blatantly unlawful (no one can be forced to perform an illegal act). The BORG structure anticipates this: the foundation’s purpose is usually narrow, and any action beyond that purpose is ultra vires (invalid). Directors are advised (and often explicitly required by the Participation Agreement) to politely refuse or delay implementation of any DAO proposal that would break laws or breach the foundation’s charter. For example, if a token vote somehow directed the BORG to distribute funds in a way that violates sanctions or securities laws, the directors’ fiduciary duty would compel them to not execute that, and instead work with the DAO to find a compliant alternative. Importantly, such clashes are extremely uncommon in practice – DAO communities rarely intentionally push for illegal outcomes, and MetaLeX’s legal architects help define the scope of the DAO’s authority up front to avoid ambiguous gray areas.
+
+In practice, if a conflict did occur, there are safeguards: the foundation’s Supervisor (if one exists) could step in to enforce the bylaws, or the directors might call for a revote after explaining the issue to the community. Because MetaLeX entities are flexible, the DAO could even amend the bylaws (with proper approvals) to adjust the entity’s mandate if needed to resolve a conflict. The key point is that MetaLeX provides a structured process to handle any tension between code-governance and law-governance. Rather than a DAO being at the mercy of individual legal actors, or a director being left unprotected if they follow the DAO, both sides are integrated into one governance system. Hardwired accountability means the directors are bound to respect DAO decisions (so they can’t just ignore the community), but fiduciary duty and legal constraints mean the DAO’s power is exercised within the bounds of law (so the community can’t unknowingly force someone into a legal violation)
+GitHub
+GitHub
+. This balanced design reassures institutional and legal-minded folks that DAO governance under MetaLeX won’t result in reckless or unlawful outcomes – there’s always a legal “circuit-breaker” if truly needed, but otherwise the DAO’s voice drives the bus.
+
+In conclusion, MetaLeX’s approach to cybernetic law is all about marrying the innovative autonomy of blockchain with the practical safeguards of the legal system. By anticipating skeptical questions – from enforceability and jurisdiction to edge-case failures – MetaLeX has built a framework that stands up to professional due diligence. The enforceability of agreements is ensured by parallel legal contracts
+GitHub
+, the legal entities provide real-world interfaces and liability shields
+GitHub
+GitHub
+, and the entire architecture is created to be as transparent, accountable, and resilient as possible. For legal professionals and regulators, MetaLeX demonstrates that decentralization need not mean lawlessness or chaos. Instead, it offers a model where code empowers organizations, and law fortifies that code – providing confidence that a MetaLeX-based organization can innovate quickly without leaving legal compliance and investor protections behind.

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
           link: '/key-terms',
         },
         {
+          text: '❓ FAQ',
+          link: '/faq',
+        },
+        {
           text: '🤖 BORGs',
           collapsed: true,
           items: [


### PR DESCRIPTION
## Summary
- add comprehensive MetaLeX Ecosystem FAQ page covering architecture, modules, compliance, and legal/regulatory concerns
- expose FAQ through site navigation for easy access

## Testing
- `npm test`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d54150d48332b89403b237df49c7