### PR TITLE
Remove inappropriate GitHub and Followin.io references from documenta…

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -192,120 +192,113 @@ This section addresses advanced questions raised by legal professionals, regulat
 
 ### Q: Are MetaLeX’s “cybernetic” on-chain agreements actually enforceable in the real world?
 
-A: Yes. MetaLeX contracts are designed to be legally binding dual agreements – every on-chain action is mirrored by a written legal contract. When parties enter a MetaLeX deal, a smart contract executes on-chain and the human-readable legal terms (stored on IPFS) are simultaneously adopted, with the transaction data populating the contract text
-GitHub
-GitHub
-. In effect, signing a MetaLeX transaction from your wallet is also cryptographically signing a conventional agreement. This Ricardian Tripler approach ties code, legal text, and parameters into one package, ensuring the smart contract’s outcomes align exactly with the legal obligations
-GitHub
+A: Yes. MetaLeX contracts are designed to be legally binding dual agreements – every on-chain action is mirrored by a written legal contract. When parties enter a MetaLeX deal, a smart contract executes on-chain and the human-readable legal terms (stored on IPFS) are simultaneously adopted, with the transaction data populating the contract text.
+
+
+. In effect, signing a MetaLeX transaction from your wallet is also cryptographically signing a conventional agreement. This Ricardian Tripler approach ties code, legal text, and parameters into one package, ensuring the smart contract’s outcomes align exactly with the legal obligations.
+
 . Because the legal agreements explicitly reference the specific smart contract address and terms, a court or arbitrator can recognize and enforce them if a dispute arises. The records on blockchain (signatures, timestamps, parameters) serve as tamper-proof evidence of the deal’s terms and each party’s commitments. In short, MetaLeX replaces “paper-only” contracts with hybrid code-and-prose contracts – they self-execute on-chain, but remain backed by traditional legal validity (e.g. offer, acceptance, and intent to be bound), giving professionals the assurances of enforceability they expect.
 
 ### Q: What if something goes wrong on-chain – say a bug, an exploit, or a disagreement about a MetaLeX contract’s outcome? Do we still have recourse?
 
-A: MetaLeX is built to handle disputes and unforeseen issues by combining automated enforcement with legal fallback mechanisms. First, MetaLeX tries to prevent disputes: the smart contracts are rigorously tested and often audited, and their behavior is transparent to all parties
-GitHub
-. But if a problem does arise (for example, a counterparty breaches an obligation or a critical bug affects the outcome), the parties are not left helpless. Because there is a parallel legal agreement for every deal, an aggrieved party can pursue remedies through normal legal channels – such as arbitration or court litigation – using the signed contract text and blockchain records as evidence. Importantly, MetaLeX’s chosen legal frameworks support this: for instance, the Cayman Islands (where many MetaLeX “BORG” entities are registered) offers specialized courts and a body of common-law precedent for complex business disputes, providing a knowledgeable forum if on-chain agreements end up in litigation
-GitHub
+A: MetaLeX is built to handle disputes and unforeseen issues by combining automated enforcement with legal fallback mechanisms. First, MetaLeX tries to prevent disputes: the smart contracts are rigorously tested and often audited, and their behavior is transparent to all parties.
+
+. But if a problem does arise (for example, a counterparty breaches an obligation or a critical bug affects the outcome), the parties are not left helpless. Because there is a parallel legal agreement for every deal, an aggrieved party can pursue remedies through normal legal channels – such as arbitration or court litigation – using the signed contract text and blockchain records as evidence. Importantly, MetaLeX’s chosen legal frameworks support this: for instance, the Cayman Islands (where many MetaLeX “BORG” entities are registered) offers specialized courts and a body of common-law precedent for complex business disputes, providing a knowledgeable forum if on-chain agreements end up in litigation.
+
 . In practice, many MetaLeX contracts include built-in dispute resolution clauses (e.g. arbitration provisions or choice-of-court agreements) to ensure there’s a clear path to resolve issues off-chain if purely on-chain resolution isn’t possible.
 
-MetaLeX’s philosophy is “trust the code for determinable outcomes, but have law as a safety net.” The system strives for lex cryptographia – where code handles routine execution and only ambiguous or wrongful situations fall back to legal processes
-GitHub
-. Day-to-day, the smart contracts and DAO governance automate decisions, but if something like a hack or an irreconcilable disagreement occurs, human legal norms re-enter to provide accountability. The bottom line for skeptical professionals: you gain the efficiency and certainty of self-executing code without giving up the ability to sue, obtain injunctions, or otherwise enforce rights through the courts when needed. MetaLeX’s own legal team (which even includes former regulatory attorneys familiar with dispute scenarios
-metalex.tech
-) has engineered the framework so that no on-chain action is beyond the reach of law.
+MetaLeX’s philosophy is “trust the code for determinable outcomes, but have law as a safety net.” The system strives for lex cryptographia – where code handles routine execution and only ambiguous or wrongful situations fall back to legal processes.
+
+. Day-to-day, the smart contracts and DAO governance automate decisions, but if something like a hack or an irreconcilable disagreement occurs, human legal norms re-enter to provide accountability. The bottom line for skeptical professionals: you gain the efficiency and certainty of self-executing code without giving up the ability to sue, obtain injunctions, or otherwise enforce rights through the courts when needed. MetaLeX’s own legal team (which even includes former regulatory attorneys familiar with dispute scenarios metalex.tech) has engineered the framework so that no on-chain action is beyond the reach of law.
 
 ### Q: MetaLeX uses Cayman foundation companies and other offshore entities as legal wrappers. Is this just regulatory arbitrage? What about jurisdiction mismatches if participants are worldwide?
 
-A: The use of jurisdictions like the Cayman Islands is intentional – not to evade law, but to provide a neutral, crypto-friendly legal home that aligns with DAO principles. Cayman “foundation companies” in particular have features ideally suited for decentralized projects: they have no shareholders or private owners, can be structured with purely charitable or mission-based purposes, and allow bylaws that hardwire DAO governance into the entity
-GitHub
-GitHub
-. This means a BORG (cybernetic organization) based in Cayman is ownerless (much like a DAO) and exists solely to carry out its stated purpose (e.g. supporting a protocol), rather than to maximize shareholder profit
-GitHub
-. By anchoring the organization in one well-defined jurisdiction, MetaLeX avoids the chaos of every multisig signer’s local laws applying at once
-GitHub
-. All participants know which law governs the entity – providing certainty and avoiding, say, a scenario where a globally distributed team accidentally creates an “unincorporated partnership” subject to dozens of countries’ regulations
-GitHub
-.
+A: The use of jurisdictions like the Cayman Islands is intentional – not to evade law, but to provide a neutral, crypto-friendly legal home that aligns with DAO principles. Cayman “foundation companies” in particular have features ideally suited for decentralized projects: they have no shareholders or private owners, can be structured with purely charitable or mission-based purposes, and allow bylaws that hardwire DAO governance into the entity.
 
-Far from being a shady haven, the Cayman Islands currently offers a robust but innovation-friendly regulatory environment. It has no hostile DAO-specific rules, and its regulators and service providers are experienced with crypto entities. In fact, Cayman foundations come with accountability measures (like requiring a local Supervisor if there are no members) that MetaLeX leverages to ensure compliance with the entity’s rules
-GitHub
-. This choice of jurisdiction also preempts certain U.S. regulatory issues – for example, by isolating potentially investment-like activities in a Cayman foundation, a DAO can avoid being viewed by U.S. authorities as an unregistered investment fund
-GitHub
+
+. This means a BORG (cybernetic organization) based in Cayman is ownerless (much like a DAO) and exists solely to carry out its stated purpose (e.g. supporting a protocol), rather than to maximize shareholder profit.
+
+. By anchoring the organization in one well-defined jurisdiction, MetaLeX avoids the chaos of every multisig signer’s local laws applying at once.
+
+. All participants know which law governs the entity – providing certainty and avoiding, say, a scenario where a globally distributed team accidentally creates an “unincorporated partnership” subject to dozens of countries’ regulations.
+
+. Far from being a shady haven, the Cayman Islands currently offers a robust but innovation-friendly regulatory environment. It has no hostile DAO-specific rules, and its regulators and service providers are experienced with crypto entities. In fact, Cayman foundations come with accountability measures (like requiring a local Supervisor if there are no members) that MetaLeX leverages to ensure compliance with the entity’s rules.
+
+. This choice of jurisdiction also preempts certain U.S. regulatory issues – for example, by isolating potentially investment-like activities in a Cayman foundation, a DAO can avoid being viewed by U.S. authorities as an unregistered investment fund.
+
 . That said, MetaLeX is not about hiding from regulation: if a MetaLeX-structured entity operates in other countries (e.g. hiring a U.S. team or serving U.S. investors), it still must comply with those local laws (securities law, tax law, etc.). The Cayman wrapper simply gives a solid legal base; from there, additional compliance (like U.S. securities exemptions, filings, KYC/AML for investors, etc.) can be layered as needed for activities in other jurisdictions. In summary, MetaLeX’s legal strategy is to choose the right tool for the job – e.g. Cayman for a global DAO foundation, Delaware for a U.S.-based non-profit subsidiary – to ensure the entity is both legally sound and aligned with decentralization, rather than to dodge oversight.
 
 ### Q: Could these legal wrappers (BORGs) be abused or have vulnerabilities? For instance, what stops a BORG’s insiders from misusing funds or power?
 
-A: MetaLeX BORGs are specifically designed to minimize the risk of insider abuse through both legal obligations and technical safeguards. Legally, every participant in a BORG (e.g. a multisig signer or board member) must sign a BORG Participation Agreement that binds them to act in the entity’s interest and follow its bylaws
-GitHub
-. This creates a direct contractual duty – if a signer attempted to misappropriate assets or act outside their authority, the foundation (via its Supervisor) and even the DAO community (as third-party beneficiaries) would have legal grounds to hold that individual accountable in court
-GitHub
+A: MetaLeX BORGs are specifically designed to minimize the risk of insider abuse through both legal obligations and technical safeguards. Legally, every participant in a BORG (e.g. a multisig signer or board member) must sign a BORG Participation Agreement that binds them to act in the entity’s interest and follow its bylaws.
+
+. This creates a direct contractual duty – if a signer attempted to misappropriate assets or act outside their authority, the foundation (via its Supervisor) and even the DAO community (as third-party beneficiaries) would have legal grounds to hold that individual accountable in court.
+
 . In other words, rogue actors face real liability for breaching their duties, which deters bad behavior beyond just the honor system.
 
-On the technical side, MetaLeX hard-codes compliance into the smart contracts. The BORG’s on-chain multi-signature wallet (typically a Gnosis SAFE) is outfitted with MetaLeX’s custom “BorgOS” extensions that act as automated watchdogs
-GitHub
-. For example, the core BORG smart contract serves as a Guard on the SAFE, whitelisting only the actions that are allowed per the BORG’s legal charter
-github.com
-. Any transaction that isn’t pre-approved (by type, amount, recipient, etc.) will be blocked by the contract guard
-github.com
-. This means that even if all human signers colluded to do something unauthorized (like sending funds to a personal address or doing an out-of-scope investment), the on-chain code would prevent it unless the proper DAO approvals or conditions are satisfied. MetaLeX’s Condition Manager can even enforce that certain actions only execute if an oracle or external condition is met (for instance, requiring an on-chain vote outcome or a price feed reading)
-github.com
-. Additionally, BORG bylaws themselves explicitly state that any asset moved outside the approved on-chain channels isn’t legally recognized – a rogue signer moving funds “off-book” would be violating bylaws and could be sued for breach of fiduciary duty
-GitHub
-GitHub
-.
+. On the technical side, MetaLeX hard-codes compliance into the smart contracts. The BORG’s on-chain multi-signature wallet (typically a Gnosis   SAFE) is outfitted with MetaLeX’s custom “BorgOS” extensions that act as automated watchdogs.
 
-To summarize, power in a BORG is tightly circumscribed: human actors are constrained by both the threat of legal action and by code that enforces the rules in real time. The MetaLeX approach delivers a “defense in depth”: if someone somehow bypasses a smart contract control, the legal agreements kick in; and if someone tries to shrug off legal duties, the smart contracts are there to stop unauthorized moves. This dual layer of protection greatly mitigates the risk of misuse or malfeasance compared to an unstructured DAO or a traditional company without such integrated controls.
+. For example, the core BORG smart contract serves as a Guard on the SAFE, whitelisting only the actions that are allowed per the BORG’s legal charter.
+
+. Any transaction that isn’t pre-approved (by type, amount, recipient, etc.) will be blocked by the contract guard.
+
+. This means that even if all human signers colluded to do something unauthorized (like sending funds to a personal address or doing an out-of-scope investment), the on-chain code would prevent it unless the proper DAO approvals or conditions are satisfied. MetaLeX’s Condition Manager can even enforce that certain actions only execute if an oracle or external condition is met (for instance, requiring an on-chain vote outcome or a price feed reading).
+
+. Additionally, BORG bylaws themselves explicitly state that any asset moved outside the approved on-chain channels isn’t legally recognized – a rogue signer moving funds “off-book” would be violating bylaws and could be sued for breach of fiduciary duty.
+
+
+. To summarize, power in a BORG is tightly circumscribed: human actors are constrained by both the threat of legal action and by code that enforces the rules in real time. The MetaLeX approach delivers a “defense in depth”: if someone somehow bypasses a smart contract control, the legal agreements kick in; and if someone tries to shrug off legal duties, the smart contracts are there to stop unauthorized moves. This dual layer of protection greatly mitigates the risk of misuse or malfeasance compared to an unstructured DAO or a traditional company without such integrated controls.
 
 ### Q: MetaLeX claims legal compliance and “bridging law and code.” How do we know this isn’t just superficial? Is the compliance truly substantive?
 
 A: It’s absolutely substantive. MetaLeX was founded by seasoned attorneys and engineers specifically to embed real legal rigor into blockchain systems – not as a marketing checkbox, but as the core of the platform
 metalex.tech
-. Every BORG or cybernetic contract MetaLeX helps create involves real legal work: drafting bespoke charters and bylaws, coordinating with law firms to register entities, and ensuring ongoing compliance. For example, when spinning up a BORG foundation, MetaLeX works with licensed Cayman counsel to formally register the company and draft its Memorandum & Articles and Bylaws in line with the DAO’s needs
-GitHub
-. They even arrange professional directors or supervisors when required by local law, and strictly limit those roles via legal documents to prevent any loopholes
-GitHub
+
+. Every BORG or cybernetic contract MetaLeX helps create involves real legal work: drafting bespoke charters and bylaws, coordinating with law firms to register entities, and ensuring ongoing compliance. For example, when spinning up a BORG foundation, MetaLeX works with licensed Cayman counsel to formally register the company and draft its Memorandum & Articles and Bylaws in line with the DAO’s needs.
+
+. They even arrange professional directors or supervisors when required by local law, and strictly limit those roles via legal documents to prevent any loopholes.
+
 . All of this is far beyond a token “paper filing” – it’s a complete legal architecture backing the on-chain operations.
 
-Moreover, MetaLeX’s smart contracts and legal documents are developed in tandem. The team’s lawyers and developers iterate together so that the bylaws and code reflect each other precisely
-GitHub
-GitHub
-. This includes defining clear processes for things like adding members, transferring tokens, or dissolving the entity, and then implementing those processes both in the legal text and in the solidity code. The goal is that anyone examining a MetaLeX structure can see that the rules aren’t just on paper: they are actively enforced by software. For instance, if the bylaws say “any change to the BORG’s multisig signers requires DAO approval,” the smart contract guard literally will not allow a new signer to be added unless a verified DAO vote has occurred
-GitHub
+Moreover, MetaLeX’s smart contracts and legal documents are developed in tandem. The team’s lawyers and developers iterate together so that the bylaws and code reflect each other precisely.
+
+
+. This includes defining clear processes for things like adding members, transferring tokens, or dissolving the entity, and then implementing those processes both in the legal text and in the solidity code. The goal is that anyone examining a MetaLeX structure can see that the rules aren’t just on paper: they are actively enforced by software. For instance, if the bylaws say “any change to the BORG’s multisig signers requires DAO approval,” the smart contract guard literally will not allow a new signer to be added unless a verified DAO vote has occurred.
+
 . This kind of cross-verification shows that compliance is built into the system’s operations, not merely its intentions.
 
-Finally, MetaLeX’s commitment to real compliance is evidenced by the projects and communities involved. Major DAO initiatives (such as the Lido community’s “Lido Alliance” foundation and others) have used MetaLeX’s framework, subjecting it to scrutiny by top law firms and DAO contributors. The fact that sophisticated stakeholders are adopting BORG structures indicates trust that these are legally sound, not just empty shells. Even MetaLeX’s experimental features like GAIB (an AI legal agent) have detailed legal safeguards (e.g. a Delaware non-profit wrapper, purpose clauses, etc.) rather than being freewheeling bots
-followin.io
-followin.io
+Finally, MetaLeX’s commitment to real compliance is evidenced by the projects and communities involved. Major DAO initiatives (such as the Lido community’s “Lido Alliance” foundation and others) have used MetaLeX’s framework, subjecting it to scrutiny by top law firms and DAO contributors. The fact that sophisticated stakeholders are adopting BORG structures indicates trust that these are legally sound, not just empty shells. Even MetaLeX’s experimental features like GAIB (an AI legal agent) have detailed legal safeguards (e.g. a Delaware non-profit wrapper, purpose clauses, etc.) rather than being freewheeling bots.
+
 . In sum, MetaLeX’s value proposition hinges on actual legal enforceability and compliance – something they’ve architected at every level of the stack.
 
 ### Q: MetaLeX relies on off-chain data and “GAIB” AI agents in some cases. Doesn’t that reintroduce trust and uncertainty? How is the oracle/agent model handled?
 
 A: MetaLeX minimizes off-chain dependencies, but when they are necessary, it handles them in a transparent and trust-managed way. Oracles (for feeding external data like prices or events) and the GAIB agent (MetaLeX’s AI legal assistant) are integrated with careful checks and balances. Here’s how:
 
-- **Decentralized & Controlled Oracles** – MetaLeX smart contracts can ingest off-chain information via oracle feeds, but these are never a single point of failure. The BORG’s Condition Manager module allows multiple conditions and approvals to be required for any action
-github.com
+- **Decentralized & Controlled Oracles** – MetaLeX smart contracts can ingest off-chain information via oracle feeds, but these are never a single point of failure. The BORG’s Condition Manager module allows multiple conditions and approvals to be required for any action.
+
 . For example, a payment might require both an oracle price and a DAO multisig approval to proceed, ensuring no oracle alone can trigger a critical transaction. Oracles can be chosen from reputable decentralized networks (like Chainlink or similar) or even a consortium of known data providers. The oracle inputs themselves are often anchored in the legal docs – the agreement will specify the data source and what happens if that source fails. This way, everyone knows which off-chain data is authoritative, and there’s a legal basis to disregard data that falls outside defined parameters (e.g. clearly erroneous feeds could be deemed invalid by contract). In short, off-chain data is brought in only with explicit, verifiable mechanisms, and usually requires human or DAO sign-off for anything consequential.
 
-- **GAIB (Governance AI Bot) with BORG Oversight** – The GAIB agent – essentially an AI programmed to assist with legal research or even sign certain low-risk transactions – is not a free-roaming AI without constraints. In fact, the GAIB agent is itself wrapped inside a MetaLeX BORG entity (in this case, a Delaware nonstock non-profit corporation) to impose legal and governance oversight
-followin.io
-. The GAIB BORG’s charter includes a “Qualified Code is Law” provision: most of the time the AI’s on-chain actions (its “code”) are treated as the final word, except in defined edge cases like obvious malfunctions or hacks
-followin.io
-. This means if the GAIB agent operates normally (e.g. reviewing a smart contract and giving a green light within its authority), its decisions can auto-execute on-chain. But if it behaves abnormally – say due to an AI glitch or it signs a clearly unauthorized transaction – the BORG’s rules allow human supervisors (and the DAO governance) to step in and override or unwind those actions
-followin.io
+- **GAIB (Governance AI Bot) with BORG Oversight** – The GAIB agent – essentially an AI programmed to assist with legal research or even sign certain low-risk transactions – is not a free-roaming AI without constraints. In fact, the GAIB agent is itself wrapped inside a MetaLeX BORG entity (in this case, a Delaware nonstock non-profit corporation) to impose legal and governance oversight.
+
+. The GAIB BORG’s charter includes a “Qualified Code is Law” provision: most of the time the AI’s on-chain actions (its “code”) are treated as the final word, except in defined edge cases like obvious malfunctions or hacks.
+
+. This means if the GAIB agent operates normally (e.g. reviewing a smart contract and giving a green light within its authority), its decisions can auto-execute on-chain. But if it behaves abnormally – say due to an AI glitch or it signs a clearly unauthorized transaction – the BORG’s rules allow human supervisors (and the DAO governance) to step in and override or unwind those actions.
+
 . Practically, GAIB’s powers are limited: it might be allowed to co-sign routine transactions or provide on-chain legal opinions, but it cannot unilaterally control funds beyond what it’s been permitted. All of its transactions still go through the SAFE multisig (where other human or DAO signers can veto if something looks off). In essence, MetaLeX treats an AI agent like any other fallible actor – it’s given a role with specified permissions, and it’s sandboxed within a legal entity so that there’s always an accountable party if something goes wrong.
 
 By combining on-chain controls with off-chain legal oversight, MetaLeX ensures that oracle feeds and AI agents enhance autonomy without compromising trust. Users and regulators can inspect the logic (open-source code, oracle addresses, AI parameters) and also take comfort that an identifiable legal entity is responsible for the outputs. The trust model thus remains multi-layered: trust the math and code where you can, but also have human governance and legal accountability watching over any automated agents.
 
 ### Q: Can MetaLeX-based organizations actually interact with traditional legal systems? For example, can a BORG own assets in the real world, sign contracts off-chain, or be taken to court?
 
-A: Absolutely. A MetaLeX “BORG” is a real legal entity (such as a foundation company or nonprofit corporation) and has all the capacities of any company in that jurisdiction. That means it can own property, intellectual property, and other assets in its own name, enter into contracts with outside parties, hire employees or contractors, and so on
-GitHub
-GitHub
-. For instance, a BORG’s foundation could hold a Web2 domain name or a patent on behalf of the DAO – something a smart contract alone cannot do – providing a crucial bridge between on-chain operations and off-chain property rights
-GitHub
+A: Absolutely. A MetaLeX “BORG” is a real legal entity (such as a foundation company or nonprofit corporation) and has all the capacities of any company in that jurisdiction. That means it can own property, intellectual property, and other assets in its own name, enter into contracts with outside parties, hire employees or contractors, and so on.
+
+. For instance, a BORG’s foundation could hold a Web2 domain name or a patent on behalf of the DAO – something a smart contract alone cannot do – providing a crucial bridge between on-chain operations and off-chain property rights.
+
 . Likewise, the BORG can open bank accounts or fiat on-ramp accounts if needed, because it has legal personhood (banks or vendors can KYC the entity and deal with it just like they would with an LLC or corporation).
 
-Importantly, a MetaLeX entity can also appear in court or arbitration as the vehicle representing the DAO’s interests. If the BORG needs to sue (or be sued), the case can be brought in the courts of its home jurisdiction (e.g. Cayman Islands court for a foundation, Delaware court for a U.S. nonstock corp). Those courts are perfectly capable of adjudicating disputes involving the entity’s bylaws or agreements – Cayman even has specialized business courts ready to handle complex crypto disputes
-GitHub
+Importantly, a MetaLeX entity can also appear in court or arbitration as the vehicle representing the DAO’s interests. If the BORG needs to sue (or be sued), the case can be brought in the courts of its home jurisdiction (e.g. Cayman Islands court for a foundation, Delaware court for a U.S. nonstock corp). Those courts are perfectly capable of adjudicating disputes involving the entity’s bylaws or agreements – Cayman even has specialized business courts ready to handle complex crypto disputes.
+
 . MetaLeX’s legal design ensures there’s always a designated agent or responsible director who can respond to legal service on the entity’s behalf, so a lawsuit won’t get stuck in a black hole. This interoperability extends to things like regulatory filings or registrations: for example, if a BORG issues tokenized shares or interests, it can maintain an official shareholder (member) register that mirrors the on-chain token holdings, satisfying company law requirements. In summary, MetaLeX entities are fully-fledged legal actors in the traditional sense, giving you the benefits of engaging with courts, registries, and counterparties, while concurrently operating with the efficiency of on-chain code.
 
 ### Q: What if regulators (like the SEC in the U.S.) crack down on crypto activities? Are MetaLeX structures prepared for regulatory scrutiny or enforcement?
@@ -314,86 +307,79 @@ A: MetaLeX is designed with regulatory compliance in mind, aiming to future-proo
 forum.zknation.io
 .
 
-Furthermore, MetaLeX structures are intentionally crafted to steer clear of the most sensitive regulatory red flags. For instance, if a BORG will be handling community funds or investments, MetaLeX will structure it so that the foundation is non-profit and has no equity owners, making it less likely to be deemed a security issuer or an “investment company”
-GitHub
-GitHub
-. Profits are not distributed to individuals; instead, any funds are used for the DAO’s purposes, which helps avoid classifications like securities dividends. In one real example, the GAIB project’s token (GAIB) was explicitly not sold as an investment – the token proceeds go into a decentralized liquidity pool, not to MetaLeX or any company’s coffers
-followin.io
-. This kind of setup was chosen so that the token functions as a utility/governance token for the AI agent, not as a share of a business
-followin.io
-. By proactively structuring offerings and entities in compliant ways (with legal guidance from experts, including ex-SEC personnel on the MetaLeX team
-metalex.tech
-), MetaLeX greatly reduces the risk of running afoul of regulations.
+Furthermore, MetaLeX structures are intentionally crafted to steer clear of the most sensitive regulatory red flags. For instance, if a BORG will be handling community funds or investments, MetaLeX will structure it so that the foundation is non-profit and has no equity owners, making it less likely to be deemed a security issuer or an “investment company.”
+
+. Profits are not distributed to individuals; instead, any funds are used for the DAO’s purposes, which helps avoid classifications like securities dividends. In one real example, the GAIB project’s token (GAIB) was explicitly not sold as an investment – the token proceeds go into a decentralized liquidity pool, not to MetaLeX or any company’s coffers.
+
+. This kind of setup was chosen so that the token functions as a utility/governance token for the AI agent, not as a share of a business.
+
+. By proactively structuring offerings and entities in compliant ways (with legal guidance from experts, including ex-SEC personnel on the MetaLeX team metalex.tech), MetaLeX greatly reduces the risk of running afoul of regulations.
 
 Of course, no structure is immune to regulatory overreach or changing laws. However, if a regulator does raise an issue, a MetaLeX BORG can respond in a formal, cooperative manner – it can hire counsel, negotiate, or implement remedial measures as needed, just like any company. Importantly, having clear bylaws and records means a MetaLeX entity can demonstrate its good-faith compliance (for example, showing a regulator the provisions that ensure token holders had to be verified, or that a DAO vote was required for certain actions, etc.). This transparency and built-in compliance make it far easier to satisfy regulators compared to an unaffiliated DAO. In summary, MetaLeX can’t guarantee that a given project won’t become subject to regulation, but it provides the tools to be compliant from day one and to adapt swiftly if the legal environment shifts.
 
 ### Q: In a MetaLeX multi-signature governance setup, who owns the IP or products created? And what about personal liability – are the multisig signers/directors personally on the hook if something goes wrong?
 
-A: Intellectual Property (IP) – MetaLeX ensures IP is owned or controlled by the legal entity (the BORG), not by the individual contributors. For example, if a team of developers within a BORG creates software or a brand, the Cayman foundation or Delaware corporation can hold the copyright or trademark. MetaLeX’s framework explicitly allows the entity to custody legal rights and IP that a smart contract can’t hold
-GitHub
-. In practice, MetaLeX often arranges for contributors to assign any created IP to the foundation, or grants the foundation a perpetual license to use it. A concrete case was the GAIB AI lawyer project: MetaLeX Labs granted the GAIB BORG a perpetual, royalty-free license to all the _gai16zbrielShapir0 AI’s intellectual property, to ensure the BORG (and by extension the community) can use the AI without risk of MetaLeX later revoking those rights
-followin.io
+A: Intellectual Property (IP) – MetaLeX ensures IP is owned or controlled by the legal entity (the BORG), not by the individual contributors. For example, if a team of developers within a BORG creates software or a brand, the Cayman foundation or Delaware corporation can hold the copyright or trademark. MetaLeX’s framework explicitly allows the entity to custody legal rights and IP that a smart contract can’t hold.
+
+. In practice, MetaLeX often arranges for contributors to assign any created IP to the foundation, or grants the foundation a perpetual license to use it. A concrete case was the GAIB AI lawyer project: MetaLeX Labs granted the GAIB BORG a perpetual, royalty-free license to all the _gai16zbrielShapir0 AI’s intellectual property, to ensure the BORG (and by extension the community) can use the AI without risk of MetaLeX later revoking those rights.
+
 . This kind of arrangement is essentially “IP escrow” – it prevents any one signer or even the founding team from monopolizing assets that are meant for the DAO’s benefit. All key assets (code, domain names, etc.) end up owned by the BORG or formally licensed to it, so they remain with the community’s vehicle even if individual people leave the project.
 
-Liability: One big advantage of the BORG legal wrapper is that it shields individual participants from personal liability in almost all normal circumstances
-GitHub
-. The foundation company or corporation is a separate legal person – it bears the brunt of any legal liability, debt, or lawsuit. Directors, officers, and multisig signers are generally not personally responsible for the entity’s obligations, as long as they are acting in good faith and in accordance with their duties
-GitHub
-. If, say, the BORG is sued or owes money, the plaintiffs can go after the foundation’s assets, not the personal assets of the multisig members. This limited liability is crucial for getting talented people to serve in these roles without fear of ruinous personal risk
-GitHub
-. Of course, the protection isn’t absolute: if a signer commits egregious wrongdoing – e.g. fraud or willful illegal activity – courts can “pierce the veil” and hold them personally accountable
-GitHub
+Liability: One big advantage of the BORG legal wrapper is that it shields individual participants from personal liability in almost all normal circumstances.
+
+. The foundation company or corporation is a separate legal person – it bears the brunt of any legal liability, debt, or lawsuit. Directors, officers, and multisig signers are generally not personally responsible for the entity’s obligations, as long as they are acting in good faith and in accordance with their duties.
+
+. If, say, the BORG is sued or owes money, the plaintiffs can go after the foundation’s assets, not the personal assets of the multisig members. This limited liability is crucial for getting talented people to serve in these roles without fear of ruinous personal risk.
+
+. Of course, the protection isn’t absolute: if a signer commits egregious wrongdoing – e.g. fraud or willful illegal activity – courts can “pierce the veil” and hold them personally accountable.
+
 . But for ordinary negligence or business losses, the BORG structure provides a corporate veil just like a normal company.
 
-To further protect individuals and encourage responsible governance, all BORG signers explicitly agree to fiduciary-like duties in the Participation Agreement and bylaws
-GitHub
-GitHub
-. They must act in the best interest of the entity/DAO mission and not for personal gain
-GitHub
+To further protect individuals and encourage responsible governance, all BORG signers explicitly agree to fiduciary-like duties in the Participation Agreement and bylaws.
+
+. They must act in the best interest of the entity/DAO mission and not for personal gain.
+
 . If they uphold those duties, they remain shielded by the entity. If they breach them (e.g. siphoning funds), then aside from legal action, they also lose the protection – a rogue signer would not only face potential lawsuit but could also be deemed acting outside their authority (and thus possibly personally liable). In summary, MetaLeX aligns incentives so that IP and value accrue to the entity/DAO, and contributors are protected when doing the right thing, but cannot secretly capture value or harm the project without serious consequences.
 
 ### Q: How does MetaLeX handle edge-case failures, like a multisig stalemate (signers not agreeing or disappearing) or a critical smart contract bug locking up funds?
 
 A: MetaLeX anticipated these scenarios and built in safety valves at both the legal and smart-contract level. Here are a few ways edge cases are handled:
 
-- **On-Chain “Eject” and Signer Replacement** – If a multisig signer becomes uncooperative or incapacitated, MetaLeX’s BORG contracts allow for their removal or replacement. There is an Eject Implant module that, when enabled, lets an authorized party (often the DAO or a designated “Authority” address) remove a signer from the Gnosis SAFE, or lets a signer voluntarily resign on-chain
-github.com
+- **On-Chain “Eject” and Signer Replacement** – If a multisig signer becomes uncooperative or incapacitated, MetaLeX’s BORG contracts allow for their removal or replacement. There is an Eject Implant module that, when enabled, lets an authorized party (often the DAO or a designated “Authority” address) remove a signer from the Gnosis SAFE, or lets a signer voluntarily resign on-chain.
+
 . Typically, the DAO (via a governance vote) would have to approve this action, preventing abuse. This ensures that if, for example, one signer disappears or refuses to sign anything (causing a stalemate), the community isn’t permanently stuck – they can vote to replace that keyholder and restore the BORG’s functionality.
 
-- **FailSafe Mechanisms** – MetaLeX BORGs also feature a FailSafe module to recover funds in emergencies
-github.com
+- **FailSafe Mechanisms** – MetaLeX BORGs also feature a FailSafe module to recover funds in emergencies.
+
 . The FailSafe can be configured with conditions such as timeouts or specific triggers. For instance, the BORG could stipulate: “If the multisig hasn’t had any activity in 6 months and XYZ conditions are met, then funds auto-transfer to the parent DAO’s treasury.”
-followin.io
- This was implemented in the GAIB BORG: if the AI agent or its multisig fails to act for a defined period, the funds revert to a MetaLeX multisig as a backstop
-followin.io
+
+ This was implemented in the GAIB BORG: if the AI agent or its multisig fails to act for a defined period, the funds revert to a MetaLeX multisig as a backstop.
+
 . FailSafes can also be triggered by a DAO vote or an oracle signal (like a “dead-man switch” condition) if something is clearly wrong. This means even if a contract upgrade is impossible or signers vanish, there’s a predefined way to claw assets back to safety.
 
-- **Legal Override for Catastrophic Events** – In the bylaws and contracts, MetaLeX often includes clauses covering force majeure or “code failure” scenarios. Essentially, the parties acknowledge that if an extreme unforeseen bug or hack occurs – something that defeats the intended functioning of the code – they will cooperate to fix it under the guidance of the DAO or through legal means. In the GAIB charter, for example, there’s a provision that “code is law” except in cases of obvious hacks or blockchain failures
-followin.io
+- **Legal Override for Catastrophic Events** – In the bylaws and contracts, MetaLeX often includes clauses covering force majeure or “code failure” scenarios. Essentially, the parties acknowledge that if an extreme unforeseen bug or hack occurs – something that defeats the intended functioning of the code – they will cooperate to fix it under the guidance of the DAO or through legal means. In the GAIB charter, for example, there’s a provision that “code is law” except in cases of obvious hacks or blockchain failures.
+
 . Those exceptions allow the community to treat such events as void/unauthorized and to seek remedies (like deploying a patch contract, or in worst case, going to court to freeze misappropriated funds). Additionally, because the BORG is a legal entity, it could file an insurance claim (if there’s coverage) or take emergency actions like hiring a forensic team without needing a new DAO vote in the heat of the moment – it has enough legal agency to respond quickly when required.
 
 In essence, MetaLeX’s design acknowledges that despite best efforts, things can go wrong. By incorporating redundant controls – the ability to vote out a stuck signer, the ability to recover assets on timeout, and legal clauses for handling the truly unexpected – the system provides a path to recovery or resolution. These measures reassure stakeholders that a MetaLeX-based organization won’t be permanently paralyzed by a single point of failure. Even in edge cases, there are procedures to fall back on, governed by either on-chain consensus or legal processes, so the organization can adapt and continue rather than collapse.
 
 ### Q: Could there be a conflict between what DAO token holders decide and what the BORG’s directors or signers are legally obligated to do? What if the DAO’s vote goes against the directors’ fiduciary duties or vice versa?
 
-A: MetaLeX’s entire approach is to align the DAO’s will with the legal entity’s duties as closely as possible, so direct conflicts are rare by design. The foundation documents of a BORG explicitly state that the entity’s purpose is to serve the DAO’s project and community
-GitHub
-. In legal terms, this means the directors’ primary “fiduciary duty” is effectively to carry out the DAO’s mission as defined in those documents. Thus, when a DAO vote is made in accordance with that mission (e.g. approving a budget or changing a protocol parameter), the BORG’s officers are actually fulfilling their duties by executing that decision. MetaLeX reinforces this alignment by embedding DAO oversight into the legal structure: many BORG bylaws include clauses that any major decisions require DAO approval (for example, adding a new board member or dissolving the entity must be voted on by token holders)
-GitHub
-. This legal requirement means the directors cannot take certain actions unilaterally even if they wanted to – the DAO’s decision is literally part of the corporate governance process, not just an informal influence. The software enforces the same; if bylaws say “DAO must approve X,” then the smart contracts will block action X until a DAO vote is confirmed on-chain
-GitHub
+A: MetaLeX’s entire approach is to align the DAO’s will with the legal entity’s duties as closely as possible, so direct conflicts are rare by design. The foundation documents of a BORG explicitly state that the entity’s purpose is to serve the DAO’s project and community.
+
+. In legal terms, this means the directors’ primary “fiduciary duty” is effectively to carry out the DAO’s mission as defined in those documents. Thus, when a DAO vote is made in accordance with that mission (e.g. approving a budget or changing a protocol parameter), the BORG’s officers are actually fulfilling their duties by executing that decision. MetaLeX reinforces this alignment by embedding DAO oversight into the legal structure: many BORG bylaws include clauses that any major decisions require DAO approval (for example, adding a new board member or dissolving the entity must be voted on by token holders).
+
+. This legal requirement means the directors cannot take certain actions unilaterally even if they wanted to – the DAO’s decision is literally part of the corporate governance process, not just an informal influence. The software enforces the same; if bylaws say “DAO must approve X,” then the smart contracts will block action X until a DAO vote is confirmed on-chain.
+
 . All of this ensures that in normal operations, there’s no divergence: the DAO’s vote and the directors’ legal obligations point in the same direction.
 
 Now, consider a scenario where a DAO passes a proposal that might be problematic – say, something outside the BORG’s legal purpose or even illegal. Because the directors are real people with legal duties, they cannot blindly follow a DAO instruction that is blatantly unlawful (no one can be forced to perform an illegal act). The BORG structure anticipates this: the foundation’s purpose is usually narrow, and any action beyond that purpose is ultra vires (invalid). Directors are advised (and often explicitly required by the Participation Agreement) to politely refuse or delay implementation of any DAO proposal that would break laws or breach the foundation’s charter. For example, if a token vote somehow directed the BORG to distribute funds in a way that violates sanctions or securities laws, the directors’ fiduciary duty would compel them to not execute that, and instead work with the DAO to find a compliant alternative. Importantly, such clashes are extremely uncommon in practice – DAO communities rarely intentionally push for illegal outcomes, and MetaLeX’s legal architects help define the scope of the DAO’s authority up front to avoid ambiguous gray areas.
 
-In practice, if a conflict did occur, there are safeguards: the foundation’s Supervisor (if one exists) could step in to enforce the bylaws, or the directors might call for a revote after explaining the issue to the community. Because MetaLeX entities are flexible, the DAO could even amend the bylaws (with proper approvals) to adjust the entity’s mandate if needed to resolve a conflict. The key point is that MetaLeX provides a structured process to handle any tension between code-governance and law-governance. Rather than a DAO being at the mercy of individual legal actors, or a director being left unprotected if they follow the DAO, both sides are integrated into one governance system. Hardwired accountability means the directors are bound to respect DAO decisions (so they can’t just ignore the community), but fiduciary duty and legal constraints mean the DAO’s power is exercised within the bounds of law (so the community can’t unknowingly force someone into a legal violation)
-GitHub
-GitHub
+In practice, if a conflict did occur, there are safeguards: the foundation’s Supervisor (if one exists) could step in to enforce the bylaws, or the directors might call for a revote after explaining the issue to the community. Because MetaLeX entities are flexible, the DAO could even amend the bylaws (with proper approvals) to adjust the entity’s mandate if needed to resolve a conflict. The key point is that MetaLeX provides a structured process to handle any tension between code-governance and law-governance. Rather than a DAO being at the mercy of individual legal actors, or a director being left unprotected if they follow the DAO, both sides are integrated into one governance system. Hardwired accountability means the directors are bound to respect DAO decisions (so they can’t just ignore the community), but fiduciary duty and legal constraints mean the DAO’s power is exercised within the bounds of law (so the community can’t unknowingly force someone into a legal violation).
+
+
 . This balanced design reassures institutional and legal-minded folks that DAO governance under MetaLeX won’t result in reckless or unlawful outcomes – there’s always a legal “circuit-breaker” if truly needed, but otherwise the DAO’s voice drives the bus.
 
-In conclusion, MetaLeX’s approach to cybernetic law is all about marrying the innovative autonomy of blockchain with the practical safeguards of the legal system. By anticipating skeptical questions – from enforceability and jurisdiction to edge-case failures – MetaLeX has built a framework that stands up to professional due diligence. The enforceability of agreements is ensured by parallel legal contracts
-GitHub
-, the legal entities provide real-world interfaces and liability shields
-GitHub
-GitHub
-, and the entire architecture is created to be as transparent, accountable, and resilient as possible. For legal professionals and regulators, MetaLeX demonstrates that decentralization need not mean lawlessness or chaos. Instead, it offers a model where code empowers organizations, and law fortifies that code – providing confidence that a MetaLeX-based organization can innovate quickly without leaving legal compliance and investor protections behind.
+In conclusion, MetaLeX’s approach to cybernetic law is all about marrying the innovative autonomy of blockchain with the practical safeguards of the legal system. By anticipating skeptical questions – from enforceability and jurisdiction to edge-case failures – MetaLeX has built a framework that stands up to professional due diligence. 
+
+The enforceability of agreements is ensured by parallel legal contracts. The legal entities provide real-world interfaces and liability shields, and the entire architecture is created to be as transparent, accountable, and resilient as possible. For legal professionals and regulators, MetaLeX demonstrates that decentralization need not mean lawlessness or chaos. Instead, it offers a model where code empowers organizations, and law fortifies that code – providing confidence that a MetaLeX-based organization can innovate quickly without leaving legal compliance and investor protections behind.


### PR DESCRIPTION
…tion

Removes inappropriate references to GitHub and Followin.io where it is not relevant to the content. This is a documentation cleanup only; no technical or semantic changes.