### PR TITLE
Expand legal document edge-case details by default

### DIFF
--- a/docs/pages/protocol/legal-document-signing.mdx
+++ b/docs/pages/protocol/legal-document-signing.mdx
@@ -163,7 +163,7 @@ A party calls `signContract` with the `contractId`, their party-specific field v
     E --> F[Agreement bound to off-chain document]`}
 />
 
-<details>
+<details open>
 <summary>Notes on Edge Cases: Delegation, Voiding, Escrow</summary>
 
 **Delegation:** The contract supports delegated signing. A party can store a delegate address plus an optional expiry in the `delegations` mapping. During `_verifySignature`, if the recovered signer is not the expected party, the contract checks whether the recovered signer is the delegate and whether the delegation is still valid (expiry is zero or in the future). This enables cases such as an executive authorizing an assistant to sign on their behalf for a limited time.


### PR DESCRIPTION
### Motivation
- Make the edge-case notes in the legal document signing page immediately visible by default to improve discoverability of delegation, voiding, and escrow explanations.

### Description
- Add `open` to the `<details>` element in `docs/pages/protocol/legal-document-signing.mdx` so the "Notes on Edge Cases: Delegation, Voiding, Escrow" section is expanded by default.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977a49b1ee88332a420cfa2c5e3cfa2)